### PR TITLE
Add Temperature Converter Module

### DIFF
--- a/Commands/ContextCommands/General/Convert_Temperature.js
+++ b/Commands/ContextCommands/General/Convert_Temperature.js
@@ -1,0 +1,216 @@
+import { ApplicationCommandType, InteractionContextType, ApplicationIntegrationType, MessageFlags, InteractionResponseType, MessageReferenceType } from 'discord-api-types/v10';
+import { JsonResponse } from '../../../Utility/utilityMethods.js';
+import { localize } from '../../../Utility/localizeResponses.js';
+import { SystemMessageTypes } from '../../../Utility/utilityConstants.js';
+
+// REGEXS
+const TemperatureRegex = new RegExp(/(?<amount>-?\d+(?:\.\d*)?)[^\S\n]*(?<degrees>°|'|deg(?:rees?)?|in)?[^\S\n]*(?<unit>c(?:(?=el[cs]ius\b|entigrades?\b|\b))|f(?:(?=ahrenheit\b|\b))|k(?:(?=elvins?\b|\b)))/gi);
+const CelsiusRegex = new RegExp(/(?<amount>-?\d+(?:\.\d*)?)[^\S\n]*(?<degrees>°|'|deg(?:rees?)?|in)?[^\S\n]*(?<unit>c(?:(?=el[cs]ius\b|entigrades?\b|\b)))/gi);
+const FahernheitRegex = new RegExp(/(?<amount>-?\d+(?:\.\d*)?)[^\S\n]*(?<degrees>°|'|deg(?:rees?)?|in)?[^\S\n]*(?<unit>f(?:(?=ahrenheit\b|\b)))/gi);
+const KelvinRegex = new RegExp(/(?<amount>-?\d+(?:\.\d*)?)[^\S\n]*(?<degrees>°|'|deg(?:rees?)?|in)?[^\S\n]*(?<unit>k(?:(?=elvins?\b|\b)))/gi);
+
+
+/**
+ * Converts given temperature
+ * @param {String} originalTemperature 
+ * @param {String} locale Locale from Context Command
+ * @returns {String}
+ */
+function convertTemperature(originalTemperature, locale)
+{
+    // Grab original scale
+    let originalScale = "";
+    if ( CelsiusRegex.test(originalTemperature) ) { originalScale = "c"; }
+    else if ( FahernheitRegex.test(originalTemperature) ) { originalScale = "f"; }
+    else if ( KelvinRegex.test(originalTemperature) ) { originalScale = "k"; }
+
+    // Grab original numerical value of Temperature
+    let originalValue = originalTemperature.match(new RegExp(/[0-9.\-]/gi));
+    originalValue = originalValue.join('');
+    originalValue = parseInt(originalValue);
+
+
+    // CONVERT! :D
+    if ( originalScale === "c" )
+    {
+        const CToF = ( originalValue * 9/5 ) + 32;
+        const CToK = originalValue + 273.15;
+        // Check for invalid Temperature
+        if ( CToK < 0 ) { return localize(locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${originalValue}`, 'C'); }
+        // Return converted temperatures
+        //return `${originalValue}C is about ${CToF.toFixed(0)}F or ${CToK.toFixed(0)}K`;
+        return localize(locale, 'TEMPERATURE_COMMAND_CONVERTED', `${originalValue}`, 'C', `${CToF.toFixed(0)}`, 'F', `${CToK.toFixed(0)}`, 'K');
+    }
+    else if ( originalScale === "f" )
+    {
+        const FToC = ( originalValue - 32 ) * 5/9;
+        const FToK = ( originalValue - 32 ) * 5/9 + 273.15;
+        // Check for invalid Temperature
+        if ( FToK < 0 ) { return localize(locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${originalValue}`, 'F'); }
+        // Return converted temperatures
+        return localize(locale, 'TEMPERATURE_COMMAND_CONVERTED', `${originalValue}`, 'F', `${FToC.toFixed(0)}`, 'C', `${FToK.toFixed(0)}`, 'K');
+    }
+    else if ( originalScale === "k" )
+    {
+        const KToC = originalValue - 273.15;
+        const KToF = ( originalValue - 273.15 ) * 9/5 + 32;
+        // Check for invalid Temperature
+        if ( originalValue < 0 ) { return localize(locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${originalValue}`, 'K'); }
+        // Return converted temperatures
+        return localize(locale, 'TEMPERATURE_COMMAND_CONVERTED', `${originalValue}`, 'K', `${KToC.toFixed(0)}`, 'C', `${KToF.toFixed(0)}`, 'F');
+    }
+}
+
+
+export const ContextCommand = {
+    /** Command's Name, supports both upper- and lower-case, and spaces
+     * @type {String}
+     */
+    name: "Convert Temperature",
+
+    /** Command's Description
+     * @type {String}
+     */
+    description: "Convert temperatures detected within sent Messages",
+
+    /** Type of Context Command
+     * @type {ApplicationCommandType}
+     */
+    commandType: ApplicationCommandType.Message,
+
+    /** Command's cooldown, in seconds (whole number integers!)
+     * @type {Number}
+     */
+    cooldown: 5,
+    
+
+    /** Get the Command's data in a format able to be registered with via Discord's API
+     * @returns {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody}
+     */
+    getRegisterData() {
+        /** @type {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody} */
+        const CommandData = {};
+
+        CommandData.name = this.name;
+        CommandData.description = "";
+        CommandData.type = this.commandType;
+        // Integration Types - 0 for GUILD_INSTALL, 1 for USER_INSTALL.
+        //  MUST include at least one. 
+        CommandData.integration_types = [ ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall ];
+        // Contexts - 0 for GUILD, 1 for BOT_DM (DMs with the App), 2 for PRIVATE_CHANNEL (DMs/GDMs that don't include the App).
+        //  MUST include at least one. PRIVATE_CHANNEL can only be used if integration_types includes USER_INSTALL
+        CommandData.contexts = [ InteractionContextType.Guild, InteractionContextType.PrivateChannel ];
+
+        return CommandData;
+    },
+
+    /** Runs the Command
+     * @param {import('discord-api-types/v10').APIMessageApplicationCommandGuildInteraction|import('discord-api-types/v10').APIMessageApplicationCommandDMInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     */
+    async executeCommand(interaction, interactionUser) {
+        // Grab Message
+        const SourceMessage = interaction.data.resolved.messages[interaction.data.target_id];
+
+        // Validate not an App/System Message
+        if ( SourceMessage.author.bot || SourceMessage.author.system || SystemMessageTypes.includes(SourceMessage.type) ) {
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'CONTEXT_COMMAND_ERROR_SYSTEM_AND_BOT_MESSAGES_UNSUPPORTED')
+                }
+            });
+        }
+
+        // Validate not a Poll Message
+        if ( SourceMessage.poll != undefined ) {
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_POLLS_NOT_SUPPORTED')
+                }
+            });
+        }
+
+        // Validate not a Forwarded Message
+        if ( SourceMessage.message_reference?.type === MessageReferenceType.Forward ) {
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_FORWARDS_NOT_SUPPORTED')
+                }
+            });
+        }
+
+        // Validate there is actually content in this Message
+        if ( !SourceMessage.content || SourceMessage.content == '' ) {
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'CONTEXT_COMMAND_ERROR_MISSING_CONTENT')
+                }
+            });
+        }
+
+        
+        // Check for temperatures in the Message
+        const MatchedTemperatures = SourceMessage.content.match(TemperatureRegex);
+
+        // If no temperatures found, ACK early
+        if ( !MatchedTemperatures || MatchedTemperatures == null ) {
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_TEMPERATURE_NOT_FOUND')
+                }
+            });
+        }
+        // If more than 10 temperatures were found
+        else if ( MatchedTemperatures.length > 10 ) {
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_EXCEEDED_TEMPERATURE_LIMIT')
+                }
+            });
+        }
+        // If one single temperature was found
+        else if ( MatchedTemperatures.length === 1 ) {
+            const ConvertedResult = convertTemperature(MatchedTemperatures.shift(), interaction.locale);
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: `[${localize(interaction.locale, 'JUMP_TO_SOURCE_MESSAGE')}](<https://discord.com/channels/${interaction.guild_id}/${interaction.channel.id}/${SourceMessage.id}>)\n${localize(interaction.locale, 'TEMPERATURE_COMMAND_SUCCESS_SINGLAR')}\n\n- ${ConvertedResult}`
+                }
+            });
+        }
+        // If between 2 and 10 temperatures were found (inclusive)
+        else {
+            let convertedResults = [];
+
+            MatchedTemperatures.forEach(item => {
+                let tempResult = convertTemperature(item, interaction.locale);
+                // WHILE statement kept from MooBot v5 (added January 2022). I STILL DON'T KNOW WHY IT BREAKS WITHOUT THIS WHILE STATEMENT!
+                // Link to MooBot v5 for the curious: https://github.com/TwilightZebby/MooBot/releases/tag/5.0.0
+                while ( !tempResult || tempResult == undefined || tempResult == null ) { tempResult = convertTemperature(item, interaction.locale); }
+                convertedResults.push(`- ${tempResult}`);
+            });
+
+            // ACK results
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: `[${localize(interaction.locale, 'JUMP_TO_SOURCE_MESSAGE')}](<https://discord.com/channels/${interaction.guild_id}/${interaction.channel.id}/${SourceMessage.id}>)\n${localize(interaction.locale, 'TEMPERATURE_COMMAND_SUCCESS_MULTIPLE')}\n\n${convertedResults.join(`\n`)}`
+                }
+            });
+        }
+    }
+}

--- a/Commands/SlashCommands/General/temperature.js
+++ b/Commands/SlashCommands/General/temperature.js
@@ -1,0 +1,216 @@
+import { ApplicationCommandType, InteractionContextType, ApplicationIntegrationType, MessageFlags, InteractionResponseType, ApplicationCommandOptionType } from 'discord-api-types/v10';
+import { JsonResponse } from '../../../Utility/utilityMethods.js';
+import { localize } from '../../../Utility/localizeResponses.js';
+
+
+export const SlashCommand = {
+    /** Command's Name, in fulllowercase (can include hyphens)
+     * @type {String}
+     */
+    name: "temperature",
+
+    /** Command's Description
+     * @type {String}
+     */
+    description: "Convert a given temperature between degrees C, F, and K",
+
+    /** Command's Localised Descriptions
+     * @type {import('discord-api-types/v10').LocalizationMap}
+     */
+    localizedDescriptions: {
+        'en-GB': 'Convert a given temperature between degrees C, F, and K',
+        'en-US': 'Convert a given temperature between degrees F, C, and K'
+    },
+
+    /** Command's cooldown, in seconds (whole number integers!)
+     * @type {Number}
+     */
+    cooldown: 5,
+
+    /**
+     * Cooldowns for specific Subcommands
+     */
+    // Where "exampleName" is either the Subcommand's Name, or a combo of both Subcommand Group Name and Subcommand Name
+    //  For ease in handling cooldowns, this should also include the root Command name as a prefix
+    // In either "rootCommandName_subcommandName" or "rootCommandName_groupName_subcommandName" formats
+    subcommandCooldown: {
+        "exampleName": 3
+    },
+    
+
+    /** Get the Command's data in a format able to be registered with via Discord's API
+     * @returns {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody}
+     */
+    getRegisterData() {
+        /** @type {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody} */
+        const CommandData = {};
+
+        CommandData.name = this.name;
+        CommandData.description = this.description;
+        CommandData.description_localizations = this.localizedDescriptions;
+        CommandData.type = ApplicationCommandType.ChatInput;
+        // Integration Types - 0 for GUILD_INSTALL, 1 for USER_INSTALL.
+        //  MUST include at least one. 
+        CommandData.integration_types = [ ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall ];
+        // Contexts - 0 for GUILD, 1 for BOT_DM (DMs with the App), 2 for PRIVATE_CHANNEL (DMs/GDMs that don't include the App).
+        //  MUST include at least one. PRIVATE_CHANNEL can only be used if integration_types includes USER_INSTALL
+        CommandData.contexts = [ InteractionContextType.Guild, InteractionContextType.PrivateChannel, InteractionContextType.BotDM ];
+        // Options
+        CommandData.options = [
+            {
+                type: ApplicationCommandOptionType.Integer,
+                name: "value",
+                description: "The temperature value you want to convert",
+                description_localizations: {
+                    'en-GB': "The temperature value you want to convert",
+                    'en-US': "The temperature value you want to convert"
+                },
+                min_value: -460,
+                max_value: 1000,
+                required: true
+            },
+            {
+                type: ApplicationCommandOptionType.String,
+                name: "scale",
+                description: "The temperature scale of the original value",
+                description_localizations: {
+                    'en-GB': "The temperature scale of the original value",
+                    'en-US': "The temperature scale of the original value"
+                },
+                required: true,
+                choices: [
+                    {
+                        name: "Celsius",
+                        name_localizations: {
+                            'en-GB': "Celsius",
+                            'en-US': "Celsius"
+                        },
+                        value: "CELSIUS"
+                    },
+                    {
+                        name: "Fahernheit",
+                        name_localizations: {
+                            'en-GB': "Fahernheit",
+                            'en-US': "Fahernheit"
+                        },
+                        value: "FAHERNHEIT"
+                    },
+                    {
+                        name: "Kelvin",
+                        name_localizations: {
+                            'en-GB': "Kelvin",
+                            'en-US': "Kelvin"
+                        },
+                        value: "KELVIN"
+                    }
+                ]
+            }
+        ];
+
+        return CommandData;
+    },
+
+    /** Handles given Autocomplete Interactions, should this Command use Autocomplete Options
+     * @param {import('discord-api-types/v10').APIApplicationCommandAutocompleteInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     */
+    async handleAutoComplete(interaction, interactionUser) {
+        return new JsonResponse({
+            type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+            data: {
+                choices: [ {name: "Not implemented yet!", value: "NOT_IMPLEMENTED"} ]
+            }
+        });
+    },
+
+    /** Runs the Command
+     * @param {import('discord-api-types/v10').APIChatInputApplicationCommandInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     * @param {String} usedCommandName 
+     */
+    async executeCommand(interaction, interactionUser, usedCommandName) {
+        // Grab inputs
+        const InputValue = interaction.data.options.find(option => option.type === ApplicationCommandOptionType.Integer);
+        const InputScale = interaction.data.options.find(option => option.type === ApplicationCommandOptionType.String);
+
+
+        // Convert
+        switch (InputScale)
+        {
+            // C TO F/K
+            case "CELSIUS":
+                const CToF = (InputValue * 9/5) + 32;
+                const CToK = InputValue + 273.15;
+                if ( CToK < 0 ) {
+                    return new JsonResponse({
+                        type: InteractionResponseType.ChannelMessageWithSource,
+                        data: {
+                            flags: MessageFlags.Ephemeral,
+                            content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${InputValue}`, 'C')
+                        }
+                    });
+                }
+
+                return new JsonResponse({
+                    type: InteractionResponseType.ChannelMessageWithSource,
+                    data: {
+                        flags: MessageFlags.Ephemeral,
+                        content: localize(interaction.locale, 'TEMPERATURE_COMMAND_CONVERTED', `${InputValue}`, 'C', `${CToF.toFixed(0)}`, 'F', `${CToK.toFixed(0)}`, 'K')
+                    }
+                });
+
+            // F TO C/K
+            case "FAHERNHEIT":
+                const FToC = (InputValue - 32) * 5/9;
+                const FToK = (InputValue - 32) * 5/9 + 273.15;
+                if ( FToK < 0 ) {
+                    return new JsonResponse({
+                        type: InteractionResponseType.ChannelMessageWithSource,
+                        data: {
+                            flags: MessageFlags.Ephemeral,
+                            content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${InputValue}`, 'F')
+                        }
+                    });
+                }
+
+                return new JsonResponse({
+                    type: InteractionResponseType.ChannelMessageWithSource,
+                    data: {
+                        flags: MessageFlags.Ephemeral,
+                        content: localize(interaction.locale, 'TEMPERATURE_COMMAND_CONVERTED', `${InputValue}`, 'F', `${FToC.toFixed(0)}`, 'C', `${FToK.toFixed(0)}`, 'K')
+                    }
+                });
+
+            // K TO C/F
+            case "KELVIN":
+                const KToC = InputValue - 273.15;
+                const KToF = (InputValue - 273.15) * 9/5 + 32;
+                if ( InputValue < 0 ) {
+                    return new JsonResponse({
+                        type: InteractionResponseType.ChannelMessageWithSource,
+                        data: {
+                            flags: MessageFlags.Ephemeral,
+                            content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${InputValue}`, 'K')
+                        }
+                    });
+                }
+
+                return new JsonResponse({
+                    type: InteractionResponseType.ChannelMessageWithSource,
+                    data: {
+                        flags: MessageFlags.Ephemeral,
+                        content: localize(interaction.locale, 'TEMPERATURE_COMMAND_CONVERTED', `${InputValue}`, 'K', `${KToC.toFixed(0)}`, 'C', `${KToF.toFixed(0)}`, 'F')
+                    }
+                });
+
+            default:
+                return new JsonResponse({
+                    type: InteractionResponseType.ChannelMessageWithSource,
+                    data: {
+                        flags: MessageFlags.Ephemeral,
+                        content: localize(interaction.locale, 'ERROR_GENERIC')
+                    }
+                });
+        }
+    }
+}

--- a/Commands/SlashCommands/General/temperature.js
+++ b/Commands/SlashCommands/General/temperature.js
@@ -135,18 +135,18 @@ export const SlashCommand = {
 
 
         // Convert
-        switch (InputScale)
+        switch (InputScale.value)
         {
             // C TO F/K
             case "CELSIUS":
-                const CToF = (InputValue * 9/5) + 32;
-                const CToK = InputValue + 273.15;
+                const CToF = (InputValue.value * 9/5) + 32;
+                const CToK = InputValue.value + 273.15;
                 if ( CToK < 0 ) {
                     return new JsonResponse({
                         type: InteractionResponseType.ChannelMessageWithSource,
                         data: {
                             flags: MessageFlags.Ephemeral,
-                            content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${InputValue}`, 'C')
+                            content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${InputValue.value}`, 'C')
                         }
                     });
                 }
@@ -155,20 +155,20 @@ export const SlashCommand = {
                     type: InteractionResponseType.ChannelMessageWithSource,
                     data: {
                         flags: MessageFlags.Ephemeral,
-                        content: localize(interaction.locale, 'TEMPERATURE_COMMAND_CONVERTED', `${InputValue}`, 'C', `${CToF.toFixed(0)}`, 'F', `${CToK.toFixed(0)}`, 'K')
+                        content: localize(interaction.locale, 'TEMPERATURE_COMMAND_CONVERTED', `${InputValue.value}`, 'C', `${CToF.toFixed(0)}`, 'F', `${CToK.toFixed(0)}`, 'K')
                     }
                 });
 
             // F TO C/K
             case "FAHERNHEIT":
-                const FToC = (InputValue - 32) * 5/9;
-                const FToK = (InputValue - 32) * 5/9 + 273.15;
+                const FToC = (InputValue.value - 32) * 5/9;
+                const FToK = (InputValue.value - 32) * 5/9 + 273.15;
                 if ( FToK < 0 ) {
                     return new JsonResponse({
                         type: InteractionResponseType.ChannelMessageWithSource,
                         data: {
                             flags: MessageFlags.Ephemeral,
-                            content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${InputValue}`, 'F')
+                            content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${InputValue.value}`, 'F')
                         }
                     });
                 }
@@ -177,20 +177,20 @@ export const SlashCommand = {
                     type: InteractionResponseType.ChannelMessageWithSource,
                     data: {
                         flags: MessageFlags.Ephemeral,
-                        content: localize(interaction.locale, 'TEMPERATURE_COMMAND_CONVERTED', `${InputValue}`, 'F', `${FToC.toFixed(0)}`, 'C', `${FToK.toFixed(0)}`, 'K')
+                        content: localize(interaction.locale, 'TEMPERATURE_COMMAND_CONVERTED', `${InputValue.value}`, 'F', `${FToC.toFixed(0)}`, 'C', `${FToK.toFixed(0)}`, 'K')
                     }
                 });
 
             // K TO C/F
             case "KELVIN":
-                const KToC = InputValue - 273.15;
-                const KToF = (InputValue - 273.15) * 9/5 + 32;
-                if ( InputValue < 0 ) {
+                const KToC = InputValue.value - 273.15;
+                const KToF = (InputValue.value - 273.15) * 9/5 + 32;
+                if ( InputValue.value < 0 ) {
                     return new JsonResponse({
                         type: InteractionResponseType.ChannelMessageWithSource,
                         data: {
                             flags: MessageFlags.Ephemeral,
-                            content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${InputValue}`, 'K')
+                            content: localize(interaction.locale, 'TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE', `${InputValue.value}`, 'K')
                         }
                     });
                 }
@@ -199,7 +199,7 @@ export const SlashCommand = {
                     type: InteractionResponseType.ChannelMessageWithSource,
                     data: {
                         flags: MessageFlags.Ephemeral,
-                        content: localize(interaction.locale, 'TEMPERATURE_COMMAND_CONVERTED', `${InputValue}`, 'K', `${KToC.toFixed(0)}`, 'C', `${KToF.toFixed(0)}`, 'F')
+                        content: localize(interaction.locale, 'TEMPERATURE_COMMAND_CONVERTED', `${InputValue.value}`, 'K', `${KToC.toFixed(0)}`, 'C', `${KToF.toFixed(0)}`, 'F')
                     }
                 });
 

--- a/Locales/en-GB.cjs
+++ b/Locales/en-GB.cjs
@@ -293,4 +293,17 @@ Additionally, both Custom Discord Emojis, and standard Unicode Emojis, are suppo
     ROLE_BUTTON_ERROR_SWAP_FAILED: `Sorry, something went wrong while trying to swap between the {{0}} and {{1}} Roles for you...`,
     ROLE_BUTTON_ERROR_SINGLE_USE_ONLY: `Sorry! You cannot swap or revoke Roles from yourself using Single-use Role Menus.\nThese Single-use Role Menus are designed to only be usable once per User per Menu.\n\nThe Role you already have from this Menu is the {{0}} Role.`,
     ROLE_BUTTON_ERROR_REQUIREMENTS_NOT_MET: `Sorry, you do not meet the Requirements to use this Role Menu.\nYou can see what this Menu's Requirements are above the Menu itself.`,
+
+
+
+    // ******* TEMPERATURE COMMANDS
+    TEMPERATURE_COMMAND_CONVERTED: `{{0}}{{1}} is about {{2}}{{3}} or {{4}}{{5}}`,
+    TEMPERATURE_COMMAND_SUCCESS_SINGLAR: `Here is your converted temperature:`,
+    TEMPERATURE_COMMAND_SUCCESS_MULTIPLE: `Here are your converted temperatures:`,
+
+    TEMPERATURE_COMMAND_ERROR_INVALID_TEMPERATURE: `:warning: {{0}}{{1}} is a temperature that cannot exist! (It is below Absolute Zero!)`,
+    TEMPERATURE_COMMAND_ERROR_TEMPERATURE_NOT_FOUND: `Sorry, but I couldn't find any temperatures to convert from that Message.`,
+    TEMPERATURE_COMMAND_ERROR_EXCEEDED_TEMPERATURE_LIMIT: `Sorry, but there are too many temperatures found in that Message!\nI have a maximum limit of 10 temperatures per Message that I can convert.`,
+    TEMPERATURE_COMMAND_ERROR_POLLS_NOT_SUPPORTED: `Sorry, I currently do not support converting temperatures inside of Polls.`,
+    TEMPERATURE_COMMAND_ERROR_FORWARDS_NOT_SUPPORTED: `Sorry, I currently do not support converting temperatures inside of Forwarded Messages.`,
 }

--- a/Locales/en-GB.cjs
+++ b/Locales/en-GB.cjs
@@ -3,6 +3,7 @@ module.exports = {
     // ******* GENERIC STUFF
     DELETE: `Delete`,
     CANCEL: `Cancel`,
+    JUMP_TO_SOURCE_MESSAGE: `Jump to source Message`,
 
     ERROR_GENERIC: `An error has occurred.`,
     ERROR_GENERIC_WITH_PREVIEW: `An error has occurred. A preview of the raw error is as follows:\n\`\`\`{{0}}\`\`\``,
@@ -23,6 +24,8 @@ module.exports = {
 
     // ******* GENERIC CONTEXT COMMAND STUFF
     CONTEXT_COMMAND_ERROR_GENERIC: `Sorry, an error occurred while trying to run this Context Command...`,
+    CONTEXT_COMMAND_ERROR_SYSTEM_AND_BOT_MESSAGES_UNSUPPORTED: `Sorry, but this Context Command cannot be used on a System or Bot Message.`,
+    CONTEXT_COMMAND_ERROR_MISSING_CONTENT: `Sorry, but that Message doesn't have any content! (Attachments aren't checked by this Context Command).`,
 
     CONTEXT_COMMAND_ERROR_COOLDOWN_SECONDS: `Please wait {{0}} more seconds before using this Context Command again.`,
     CONTEXT_COMMAND_ERROR_COOLDOWN_MINUTES: `Please wait {{0}} more minutes before using this Context Command again.`,

--- a/Utility/interactions.js
+++ b/Utility/interactions.js
@@ -10,6 +10,9 @@ export const SlashCommands = {
 
     // ***** FOR ROLE MENUS
     'rolemenu': () => import('../Commands/SlashCommands/RoleMenus/rolemenu.js'),
+
+    // ***** FOR GENERAL COMMANDS
+    'temperature': () => import('../Commands/SlashCommands/General/temperature.js'),
 }
 
 export const ContextCommands = {

--- a/Utility/interactions.js
+++ b/Utility/interactions.js
@@ -19,6 +19,9 @@ export const ContextCommands = {
     // ***** FOR ROLE MENUS
     'Edit Role Menu': () => import('../Commands/ContextCommands/RoleMenus/Edit_Role_Menu.js'),
     'Delete Role Menu': () => import('../Commands/ContextCommands/RoleMenus/Delete_Role_Menu.js'),
+
+    // ***** FOR GENERAL COMMANDS
+    'Convert Temperature': () => import('../Commands/ContextCommands/General/Convert_Temperature.js'),
 }
 
 export const Autocompletes = {

--- a/Utility/utilityConstants.js
+++ b/Utility/utilityConstants.js
@@ -1,5 +1,6 @@
 import { Collection } from '@discordjs/collection';
 import { EmbedBuilder, ButtonBuilder, ActionRowBuilder } from '@discordjs/builders';
+import { MessageType } from 'discord-api-types/v10';
 
 
 // *******************************
@@ -34,6 +35,9 @@ export const UtilityCollections = {
     RoleMenuManagement: new Collection()
 };
 
+
+
+
 /** RegEx for Role Mentions */
 export const RoleMentionRegEx = new RegExp(/<@&(\d{17,20})>/g);
 
@@ -42,6 +46,43 @@ export const DiscordEmojiRegex = new RegExp(/<a?:(?<name>[a-zA-Z0-9\_]+):(?<id>\
 
 /** RegEx for Hex Colour Codes */
 export const HexColourRegex = new RegExp(/#[0-9a-fA-F]{6}/);
+
+
+
+export const SystemMessageTypes = [
+    MessageType.RecipientAdd, MessageType.RecipientRemove, MessageType.Call, MessageType.ChannelNameChange,
+    MessageType.ChannelIconChange, MessageType.ChannelPinnedMessage, MessageType.UserJoin, MessageType.GuildBoost,
+    MessageType.GuildBoostTier1, MessageType.GuildBoostTier2, MessageType.GuildBoostTier3, MessageType.ChannelFollowAdd,
+    MessageType.GuildDiscoveryDisqualified, MessageType.GuildDiscoveryRequalified, MessageType.GuildDiscoveryGracePeriodInitialWarning,
+    MessageType.GuildDiscoveryGracePeriodFinalWarning, MessageType.ThreadCreated, MessageType.GuildInviteReminder, MessageType.AutoModerationAction,
+    MessageType.RoleSubscriptionPurchase, MessageType.InteractionPremiumUpsell, MessageType.StageStart, MessageType.StageEnd, MessageType.StageSpeaker,
+    MessageType.StageRaiseHand, MessageType.StageTopic, MessageType.GuildApplicationPremiumSubscription, MessageType.GuildIncidentAlertModeEnabled,
+    MessageType.GuildIncidentAlertModeDisabled, MessageType.GuildIncidentReportRaid, MessageType.GuildIncidentReportFalseAlarm,
+    MessageType.PurchaseNotification, MessageType.PollResult,
+    // Not added to D-API-Types yet, or was deprecated/deleted (but keeping in here just in case)
+    13, // GUILD_STREAM - Possibly deprecated
+    33, // PRIVATE_CHANNEL_INTEGRATION_ADDED - Deprecated in favour of Interaction Contexts
+    34, // PRIVATE_CHANNEL_INTEGRATION_REMOVED - Deprecated in favour of Interaction Contexts
+    35, // PREMIUM_REFERRAL - Not added to D-API-Types
+    40, // GUILD_DEADCHAT_REVIVE_PROMPT - Experiment was probably sliently scrapped
+    41, // CUSTOM_GIFT - Not added to D-API-Types.
+    42, // GUILD_GAMING_STATS_PROMPT - Behind an experiment currently
+    43, // POLL - Deprecated in favour of <Message>.poll I believe?
+    45, // VOICE_HANGOUT_INVITE - Either deprecated or was a scrapped experiment?
+    47, // CHANGELOG - Used only TWICE before being scrapped due to r/discordapp complaints. Zebby liked having Discord Changelogs in System DMs, but whatever...
+    48, // NITRO_NOTIFICATION - Has this ever been used? 
+    49, // CHANNEL_LINKED_TO_LOBBY - Behind an experiment currently
+    50, // GIFTING_PROMPT - Part of the Friendship Anniversary Experiment
+    51, // IN_GAME_MESSAGE_NUX - Behind an experiment currently
+    52, // GUILD_JOIN_REQUEST_ACCEPT_NOTIFICATION - Not yet added to D-API-Types (part of Membership Screening v2, which was revived for Gaming Guilds)
+    53, // GUILD_JOIN_REQUEST_REJECT_NOTIFICATION - Not yet added to D-API-Types (part of Membership Screening v2, which was revived for Gaming Guilds)
+    54, // GUILD_JOIN_REQUEST_WITHDRAWN_NOTIFICATION - Not yet added to D-API-Types (part of Membership Screening v2, which was revived for Gaming Guilds)
+    55, // HD_STREAMING_UPGRADED - Part of the HD Splash Potion Experiment (or has it fully released now?)
+];
+
+
+
+
 
 /** Endpoint for sending Messages (outside of Interactions)
  * @param channelId ID of the Channel to create a new Message in

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@discordjs/builders": "^1.10.0",
         "@discordjs/collection": "^2.1.1",
-        "discord-api-types": "^0.37.117",
+        "discord-api-types": "^0.37.118",
         "discord-interactions": "^4.1.0",
         "emoji-regex": "^10.4.0",
         "itty-router": "^5.0.18",
@@ -745,9 +745,9 @@
       "license": "MIT"
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.117",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.117.tgz",
-      "integrity": "sha512-d+Z6RKd7v3q22lsil7yASucqMfVVV0s0XSqu3cw7kyHVXiDO/mAnqMzqma26IYnIm2mk3TlupYJDGrdL908ZKA==",
+      "version": "0.37.118",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.118.tgz",
+      "integrity": "sha512-MQkHHZcytmNQ3nQOBj6a0z38swsmHiROX7hdayfd0eWVrLxaQp/6tWBZ7FO2MCKKsc+W3QWnnfOJTbtyk8C4TQ==",
       "license": "MIT"
     },
     "node_modules/discord-interactions": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@discordjs/builders": "^1.10.0",
     "@discordjs/collection": "^2.1.1",
-    "discord-api-types": "^0.37.117",
+    "discord-api-types": "^0.37.118",
     "discord-interactions": "^4.1.0",
     "emoji-regex": "^10.4.0",
     "itty-router": "^5.0.18",


### PR DESCRIPTION
Adds the following:
- **Slash Commands**
  - `/temperature` (for converting a single temperature)
- **Message Context Commands**
  - "`Convert Temperatures`" (for converting up to 10 temperatures from a single Message)

Some notes for when using the Message Context Command:
- The limit of 10 temperatures per Message is enforced to ensure the 3-second Interaction Response limit is kept to
- Temperatures found in Polls cannot be converted at this time.
- Likewise, temperatures found within Forwarded Messages also cannot be converted at this time.