### PR TITLE
Add support for Discord's Components v2

### DIFF
--- a/Commands/ContextCommands/RoleMenus/Delete_Role_Menu.js
+++ b/Commands/ContextCommands/RoleMenus/Delete_Role_Menu.js
@@ -59,9 +59,9 @@ export const ContextCommand = {
     async executeCommand(interaction, interactionUser) {
         // Grab data
         const SourceMessage = interaction.data.resolved.messages[interaction.data.target_id];
-        const SourceEmbed = SourceMessage.embeds.shift();
-        const SourceMenuType = SourceEmbed?.footer?.text.split(": ").pop();
         const SourceComponents = SourceMessage.components;
+        let findMenuType = SourceComponents[0].components.find(component => component.id === 6);
+        const SourceMenuType = findMenuType != undefined ? findMenuType.content.split(": ").pop() : undefined;
 
         // Validate Message this was used on *does* contain one of TwiLite's Role Menus
         if ( SourceMessage.author.id !== DISCORD_APP_USER_ID ) {

--- a/Commands/ContextCommands/RoleMenus/Edit_Role_Menu.js
+++ b/Commands/ContextCommands/RoleMenus/Edit_Role_Menu.js
@@ -110,7 +110,7 @@ export const ContextCommand = {
         }
 
         // For later
-        const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+        const UserId = interaction.member.user.id;
 
         // Create localised components
         const SelectMenu = new ActionRowBuilder().addComponents([

--- a/Commands/ContextCommands/RoleMenus/Edit_Role_Menu.js
+++ b/Commands/ContextCommands/RoleMenus/Edit_Role_Menu.js
@@ -1,4 +1,4 @@
-import { ApplicationCommandType, InteractionContextType, ApplicationIntegrationType, MessageFlags, InteractionResponseType, PermissionFlagsBits } from 'discord-api-types/v10';
+import { ApplicationCommandType, InteractionContextType, ApplicationIntegrationType, MessageFlags, InteractionResponseType, PermissionFlagsBits, ComponentType } from 'discord-api-types/v10';
 import { JsonResponse } from '../../../Utility/utilityMethods.js';
 import { localize } from '../../../Utility/localizeResponses.js';
 import { DISCORD_APP_USER_ID } from '../../../config.js';
@@ -60,9 +60,9 @@ export const ContextCommand = {
     async executeCommand(interaction, interactionUser) {
         // Grab data
         const SourceMessage = interaction.data.resolved.messages[interaction.data.target_id];
-        const SourceEmbed = SourceMessage.embeds.shift();
-        const SourceMenuType = SourceEmbed?.footer?.text.split(": ").pop();
         const SourceComponents = SourceMessage.components;
+        let findMenuType = SourceComponents[0].components.find(component => component.id === 6);
+        const SourceMenuType = findMenuType != undefined ? findMenuType.content.split(": ").pop() : undefined;
 
         // Validate Message this was used on *does* contain one of TwiLite's Role Menus
         if ( SourceMessage.author.id !== DISCORD_APP_USER_ID ) {
@@ -128,15 +128,28 @@ export const ContextCommand = {
         
 
         // ***** Setup for Menu Configuration
+        // Convert Component v2-based menu into Embed-based preview (Menu Type was already done above)
+        let menuTitleComponent = SourceComponents[0].components.find(component => component.id === 2);
+        let menuDescriptionComponent = SourceComponents[0].components.find(component => component.id === 3);
+        let menuRequirementComponent = SourceComponents[0].components.find(component => component.id === 5);
+        
+        // Pull Action Rows out
+        let menuActionRowComponents = SourceComponents[0].components.filter(component => component.type === ComponentType.ActionRow);
+
+
         // Make the Embed Builder
-        let menuEmbedBuilder = new EmbedBuilder(SourceEmbed);
+        let menuEmbedBuilder = new EmbedBuilder();
+        menuEmbedBuilder.setTitle(menuTitleComponent.content);
+        if ( menuDescriptionComponent != undefined && menuDescriptionComponent.content != "" ) {
+            menuEmbedBuilder.setDescription(menuDescriptionComponent.content);
+        }
 
         // Make the Button Builders
         let menuButtonBuilders = [];
         let menuComponentsJson = [];
         let temp = new ActionRowBuilder();
 
-        SourceComponents.forEach(menuRow => {
+        menuActionRowComponents.forEach(menuRow => {
             menuRow.components.forEach(roleButton => {
                 let tempButton = new ButtonBuilder(roleButton);
                 menuButtonBuilders.push(tempButton);
@@ -159,7 +172,10 @@ export const ContextCommand = {
         });
 
         // Grab Requirements
-        let menuRequirements = Array.from(SourceMessage.content.matchAll(RoleMentionRegEx), (m) => m[0]);
+        let menuRequirements = [];
+        if ( menuRequirementComponent != undefined && menuRequirementComponent.content != "" ) {
+            menuRequirements = Array.from(menuRequirementComponent.content.matchAll(RoleMentionRegEx), (m) => m[0]);
+        }
 
         // Create timestamp for when Interaction expires
         //   Mainly because we can't use the Interaction after it expires

--- a/Commands/SlashCommands/Actions/bonk.js
+++ b/Commands/SlashCommands/Actions/bonk.js
@@ -79,6 +79,16 @@ export const SlashCommand = {
                 required: false
             },
             {
+                type: ApplicationCommandOptionType.Boolean,
+                name: "block-return",
+                description: "Set to TRUE to prevent the \"Return Bonk\" Button from being included in the response",
+                description_localizations: {
+                    'en-GB': "Set to TRUE to prevent the \"Return Bonk\" Button from being included in the response",
+                    'en-US': "Set to TRUE to prevent the \"Return Bonk\" Button from being included in the response"
+                },
+                required: false
+            },
+            {
                 type: ApplicationCommandOptionType.String,
                 name: "reason",
                 description: "An optional custom reason to be added onto the end of the displayed message",

--- a/Commands/SlashCommands/Actions/boop.js
+++ b/Commands/SlashCommands/Actions/boop.js
@@ -79,6 +79,16 @@ export const SlashCommand = {
                 required: false
             },
             {
+                type: ApplicationCommandOptionType.Boolean,
+                name: "block-return",
+                description: "Set to TRUE to prevent the \"Return Boop\" Button from being included in the response",
+                description_localizations: {
+                    'en-GB': "Set to TRUE to prevent the \"Return Boop\" Button from being included in the response",
+                    'en-US': "Set to TRUE to prevent the \"Return Boop\" Button from being included in the response"
+                },
+                required: false
+            },
+            {
                 type: ApplicationCommandOptionType.String,
                 name: "reason",
                 description: "An optional custom reason to be added onto the end of the displayed message",

--- a/Commands/SlashCommands/Actions/headpat.js
+++ b/Commands/SlashCommands/Actions/headpat.js
@@ -79,6 +79,16 @@ export const SlashCommand = {
                 required: false
             },
             {
+                type: ApplicationCommandOptionType.Boolean,
+                name: "block-return",
+                description: "Set to TRUE to prevent the \"Return Headpat\" Button from being included in the response",
+                description_localizations: {
+                    'en-GB': "Set to TRUE to prevent the \"Return Headpat\" Button from being included in the response",
+                    'en-US': "Set to TRUE to prevent the \"Return Headpat\" Button from being included in the response"
+                },
+                required: false
+            },
+            {
                 type: ApplicationCommandOptionType.String,
                 name: "reason",
                 description: "An optional custom reason to be added onto the end of the displayed message",

--- a/Commands/SlashCommands/Actions/hug.js
+++ b/Commands/SlashCommands/Actions/hug.js
@@ -79,6 +79,16 @@ export const SlashCommand = {
                 required: false
             },
             {
+                type: ApplicationCommandOptionType.Boolean,
+                name: "block-return",
+                description: "Set to TRUE to prevent the \"Return Hug\" Button from being included in the response",
+                description_localizations: {
+                    'en-GB': "Set to TRUE to prevent the \"Return Hug\" Button from being included in the response",
+                    'en-US': "Set to TRUE to prevent the \"Return Hug\" Button from being included in the response"
+                },
+                required: false
+            },
+            {
                 type: ApplicationCommandOptionType.String,
                 name: "reason",
                 description: "An optional custom reason to be added onto the end of the displayed message",

--- a/Commands/SlashCommands/Actions/kiss.js
+++ b/Commands/SlashCommands/Actions/kiss.js
@@ -79,6 +79,16 @@ export const SlashCommand = {
                 required: false
             },
             {
+                type: ApplicationCommandOptionType.Boolean,
+                name: "block-return",
+                description: "Set to TRUE to prevent the \"Return Kiss\" Button from being included in the response",
+                description_localizations: {
+                    'en-GB': "Set to TRUE to prevent the \"Return Kiss\" Button from being included in the response",
+                    'en-US': "Set to TRUE to prevent the \"Return Kiss\" Button from being included in the response"
+                },
+                required: false
+            },
+            {
                 type: ApplicationCommandOptionType.String,
                 name: "reason",
                 description: "An optional custom reason to be added onto the end of the displayed message",

--- a/Commands/SlashCommands/RoleMenus/rolemenu.js
+++ b/Commands/SlashCommands/RoleMenus/rolemenu.js
@@ -183,7 +183,7 @@ export const SlashCommand = {
             let selectJson = SelectMenu.toJSON();
 
             // Cache Interaction so we can refer back to the original response :)
-            const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+            const UserId = interaction.member.user.id;
             UtilityCollections.RoleMenuManagement.set(UserId, { interactionId: interaction.id, interactionToken: interaction.token, selectMenu: SelectMenu, menuEmbed: new EmbedBuilder(), menuButtons: [], roleRequirements: [], mainInstructions: localize(interaction.locale, 'ROLE_MENU_CREATE_INTRUCTIONS', timestampFor15Minutes) });
             
             // ACK

--- a/Interactions/Buttons/Actions/return-action.js
+++ b/Interactions/Buttons/Actions/return-action.js
@@ -1,5 +1,5 @@
 import { InteractionResponseType, MessageFlags } from 'discord-api-types/v10';
-import { JsonResponse } from '../Utility/utilityMethods.js';
+import { JsonResponse } from '../../../Utility/utilityMethods.js';
 import { localize } from '../../../Utility/localizeResponses.js';
 import { DISCORD_APP_USER_ID, DISCORD_TOKEN } from '../../../config.js';
 

--- a/Interactions/Buttons/Actions/return-action.js
+++ b/Interactions/Buttons/Actions/return-action.js
@@ -74,6 +74,7 @@ export const Button = {
                 'Content-Type': 'application/json',
                 Authorization: `Bot ${DISCORD_TOKEN}`
             },
+            method: "POST",
             body: {
                 "type": InteractionResponseType.UpdateMessage,
                 "data": {
@@ -88,12 +89,10 @@ export const Button = {
                     'Content-Type': 'application/json',
                     Authorization: `Bot ${DISCORD_TOKEN}`
                 },
+                method: "POST",
                 body: {
-                    "type": InteractionResponseType.UpdateMessage,
-                    "data": {
-                        "allowed_mentions": { "parse": [] },
-                        "content": displayMessage
-                    }
+                    "allowed_mentions": { "parse": [] },
+                    "content": displayMessage
                 }
             });
         }

--- a/Interactions/Buttons/Actions/return-action.js
+++ b/Interactions/Buttons/Actions/return-action.js
@@ -1,0 +1,103 @@
+import { InteractionResponseType, MessageFlags } from 'discord-api-types/v10';
+import { JsonResponse } from '../Utility/utilityMethods.js';
+import { localize } from '../../../Utility/localizeResponses.js';
+import { DISCORD_APP_USER_ID, DISCORD_TOKEN } from '../../../config.js';
+
+
+export const Button = {
+    /** The Button's name - set as the START of the Button's Custom ID, with extra data being separated with a "_" AFTER the name
+     * @example "buttonName_extraData"
+     * @type {String}
+     */
+    name: "return-action",
+
+    /** Button's Description, mostly for reminding me what it does!
+     * @type {String}
+     */
+    description: "Returns a sent Action",
+
+    /** Button's cooldown, in seconds (whole number integers!)
+     * @type {Number}
+     */
+    cooldown: 5,
+
+    /** Runs the Button
+     * @param {import('discord-api-types/v10').APIMessageComponentButtonInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     */
+    async executeButton(interaction, interactionUser) {
+        // Parse params out of Custom ID
+        const CustomParams = interaction.data.custom_id.split("_");
+        const ActionName = CustomParams[1].toUpperCase();
+        const OriginalUserId = CustomParams[2];
+        const OriginalTargetId = CustomParams[3];
+
+
+        // Ensure User who pressed Button isn't the original sender of the Action
+        if ( (interaction.member?.user?.id === OriginalUserId) || (interaction.user?.id === OriginalUserId) ) {
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'ACTION_ERROR_CANNOT_RETURN_TO_SENDER')
+                }
+            });
+        }
+
+        // Ensure User who pressed Button is the original Target of the Action
+        if ( (interaction.member?.user?.id !== OriginalTargetId) && (interaction.user?.id !== OriginalTargetId) ) {
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'ACTION_ERROR_RETURN_NOT_TARGETED_AT_SELF')
+                }
+            });
+        }
+
+
+        // Grab display names
+        let originalTriggeringUserName = interaction.message.interaction_metadata?.user.global_name != null ? interaction.message.interaction_metadata?.user.global_name : interaction.message.interaction_metadata?.user.username;
+        let originalTargetUserName = interaction.member != undefined && interaction.member?.nick != null ? interaction.member.nick
+            : interaction.member != undefined && interaction.member?.nick == null && interaction.member?.user.global_name != null ? interaction.member.user.global_name
+            : interaction.member != undefined && interaction.member?.nick == null && interaction.member?.user.global_name == null ? interaction.member.user.username
+            : interaction.member == undefined && interaction.user?.global_name != null ? interaction.user.global_name
+            : interaction.user.username;
+
+        
+        // Construct display message
+        let displayMessage = localize(interaction.guild_locale != undefined ? interaction.guild_locale : interaction.locale, `ACTION_RETURN_${ActionName}`, originalTargetUserName, originalTriggeringUserName);
+
+        // ACK & remove Button
+        let patchOutButton = await fetch(`https://discord.com/api/v10/interactions/${interaction.id}/${interaction.token}/callback`, {
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bot ${DISCORD_TOKEN}`
+            },
+            body: {
+                "type": InteractionResponseType.UpdateMessage,
+                "data": {
+                    "components": []
+                }
+            }
+        });
+
+        if ( patchOutButton.status === 204 ) {
+            await fetch(`https://discord.com/api/v10/webhooks/${DISCORD_APP_USER_ID}/${interaction.token}`, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bot ${DISCORD_TOKEN}`
+                },
+                body: {
+                    "type": InteractionResponseType.UpdateMessage,
+                    "data": {
+                        "allowed_mentions": { "parse": [] },
+                        "content": displayMessage
+                    }
+                }
+            });
+        }
+
+        return new JsonResponse({ error: 'Unknown Type' }, { status: 400 });
+    }
+}

--- a/Interactions/Buttons/RoleMenus/role.js
+++ b/Interactions/Buttons/RoleMenus/role.js
@@ -74,13 +74,16 @@ async function grantRevokeRole(interaction) {
 
 
     // Check for menu requirements
-    let menuMessageContent = interaction.message.content;
+    const SourceComponents = SourceMessage.components;
+    let findMenuType = SourceComponents[0].components.find(component => component.id === 6);
+    const SourceMenuType = findMenuType != undefined ? findMenuType.content.split(": ").pop() : undefined;
+    let menuRequirementComponent = SourceComponents[0].components.find(component => component.id === 5);
+
     /** @type {Array<String>} */
     let menuRequirements = [];
 
-    if ( menuMessageContent.trim() != "" ) {
-        let findMentions = Array.from(menuMessageContent.matchAll(RoleMentionRegEx), (m) => m[0]);
-        findMentions.forEach(tempMention => { menuRequirements.push(`${tempMention.slice(3, -1)}`); });
+    if ( menuRequirementComponent != undefined && menuRequirementComponent.content != "" ) {
+        menuRequirements = Array.from(menuRequirementComponent.content.matchAll(RoleMentionRegEx), (m) => m[0]);
     }
 
     if ( menuRequirements.length > 0 ) {
@@ -112,11 +115,7 @@ async function grantRevokeRole(interaction) {
     // Fetch Role ID
     const RoleID = interaction.data.custom_id.split("_").pop();
 
-    // Check what Menu Type this is
-    const MessageEmbed = interaction.message.embeds.shift();
-    const MenuType = MessageEmbed.footer.text.split(": ").pop();
-
-    switch (MenuType) {
+    switch (SourceMenuType) {
         // Classic Role Menu. Grants Role if User doesn't have it, revokes Role if User does have it.
         case "TOGGLE":
             return await toggleRole(interaction, RoleID);

--- a/Interactions/Buttons/RoleMenus/role.js
+++ b/Interactions/Buttons/RoleMenus/role.js
@@ -153,7 +153,7 @@ async function grantRevokeRole(interaction) {
 async function editRoleButton(interaction) {
     // Grab Role ID and cache
     const RoleId = interaction.data.custom_id.split("_").pop();
-    const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+    const UserId = interaction.member.user.id;
     let menuCache = UtilityCollections.RoleMenuManagement.get(UserId);
     let currentLabel = undefined;
     let currentEmoji = undefined;

--- a/Interactions/Modals/RoleMenus/menu-button-text.js
+++ b/Interactions/Modals/RoleMenus/menu-button-text.js
@@ -65,7 +65,7 @@ export const Modal = {
 
         // New Button details are validated. Now, construct the new Button and add to Menu!
         // ...after fetching the current Menu's details first
-        const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+        const UserId = interaction.member.user.id;
         let originalResponse = UtilityCollections.RoleMenuManagement.get(UserId);
 
         

--- a/Interactions/Modals/RoleMenus/menu-edit-button.js
+++ b/Interactions/Modals/RoleMenus/menu-edit-button.js
@@ -65,7 +65,7 @@ export const Modal = {
 
 
         // Update Button in cache
-        const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+        const UserId = interaction.member.user.id;
         let menuCache = UtilityCollections.RoleMenuManagement.get(UserId);
 
         for ( let i = 0; i <= menuCache.menuButtons.length - 1; i++ ) {

--- a/Interactions/Modals/RoleMenus/menu-embed.js
+++ b/Interactions/Modals/RoleMenus/menu-embed.js
@@ -33,7 +33,7 @@ export const Modal = {
             });
         });
 
-        const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+        const UserId = interaction.member.user.id;
         let menuCache = UtilityCollections.RoleMenuManagement.get(UserId);
 
         // Set new Embed values

--- a/Interactions/Selects/RoleMenus/configure-role-menu.js
+++ b/Interactions/Selects/RoleMenus/configure-role-menu.js
@@ -63,7 +63,7 @@ export const Select = {
 
         // Grab selected value & User ID
         const InputOption = interaction.data.values.shift();
-        const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+        const UserId = interaction.member.user.id;
 
         switch (InputOption) {
             // Set Menu Type
@@ -267,7 +267,7 @@ async function saveAndDisplay(interaction) {
 
 
     // Redo Buttons into Rows so that Discord's API won't give me a 400 response :S
-    const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+    const UserId = interaction.member.user.id;
     const MenuCache = UtilityCollections.RoleMenuManagement.get(UserId);
 
     let roleButtons = [];

--- a/Interactions/Selects/RoleMenus/configure-role-menu.js
+++ b/Interactions/Selects/RoleMenus/configure-role-menu.js
@@ -289,8 +289,45 @@ async function saveAndDisplay(interaction) {
         }
     });
 
-    // Also redo Embed for same reason as the Buttons above :c
-    let embedJson = MenuCache.menuEmbed.toJSON();
+    // Convert Embed into using Components v2, for displaying Menu in :)
+    //    NOTE: I'm not converting the Preview shown during editing yet as I figure that would be easier to do via a web dashboard in future
+
+    // Menu Details
+    let menuDetailsComponents = [
+        // Menu Title
+        {
+            "id": 2,
+            "type": ComponentType.TextDisplay,
+            "content": `## ${MenuCache.menuEmbed.data.title}`
+        }
+    ];
+    // Menu Description
+    if ( MenuCache.menuEmbed.data.description != undefined ) {
+        menuDetailsComponents.push({ "id": 3, "type": ComponentType.TextDisplay, "content": MenuCache.menuEmbed.data.description });
+    }
+    // Menu Role List
+    let menuRoleList = "";
+    menuRoleList += MenuCache.menuEmbed.data.fields.shift().value;
+    if ( MenuCache.menuEmbed.data.fields?.length > 0 ) { menuRoleList += `\n${MenuCache.menuEmbed.data.fields.shift().value}`; }
+    menuDetailsComponents.push({ "id": 4, "type": ComponentType.TextDisplay, "content": menuRoleList });
+    // Menu Requirements
+    if ( menuRequirements.length > 0 ) {
+        menuDetailsComponents.push({ "id": 5, "type": ComponentType.TextDisplay, "content": `-# ${requirementString}` });
+    }
+    // Menu Type
+    menuDetailsComponents.push({ "id": 6, "type": ComponentType.TextDisplay, "content": `-# ${MenuCache.menuEmbed.data.footer?.text}` });
+    
+    // Add Action Row with Role Buttons
+    menuDetailsComponents.push(roleButtons);
+        
+    
+    let convertToComponents = {
+        "id": 1,
+        "type": ComponentType.Container,
+        "accent_color": MenuCache.menuEmbed.data.color != undefined ? MenuCache.menuEmbed.data.color : null,
+        "spoiler": false,
+        "components": menuDetailsComponents
+    };
 
 
     // Post Menu
@@ -301,9 +338,8 @@ async function saveAndDisplay(interaction) {
             Authorization: `Bot ${DISCORD_TOKEN}`
         },
         body: JSON.stringify({
-            content: requirementString,
-            embeds: [embedJson],
-            components: roleButtons,
+            flags: MessageFlags.IsComponentsV2,
+            components: convertToComponents,
             allowed_mentions: { parse: [] }
         })
     });

--- a/Interactions/Selects/RoleMenus/create-role-menu.js
+++ b/Interactions/Selects/RoleMenus/create-role-menu.js
@@ -340,7 +340,7 @@ async function saveAndDisplay(interaction) {
         },
         body: JSON.stringify({
             flags: MessageFlags.IsComponentsV2,
-            components: roleButtons,
+            components: convertToComponents,
             allowed_mentions: { parse: [] }
         })
     });

--- a/Interactions/Selects/RoleMenus/create-role-menu.js
+++ b/Interactions/Selects/RoleMenus/create-role-menu.js
@@ -1,4 +1,4 @@
-import { InteractionResponseType, MessageFlags, TextInputStyle } from 'discord-api-types/v10';
+import { ComponentType, InteractionResponseType, MessageFlags, TextInputStyle } from 'discord-api-types/v10';
 import { ActionRowBuilder, ModalBuilder, RoleSelectMenuBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, TextInputBuilder } from '@discordjs/builders';
 import { localize } from '../../../Utility/localizeResponses.js';
 import { JsonResponse } from '../../../Utility/utilityMethods.js';
@@ -290,8 +290,45 @@ async function saveAndDisplay(interaction) {
         }
     });
 
-    // Also redo Embed for same reason as the Buttons above :c
-    let embedJson = MenuCache.menuEmbed.toJSON();
+    // Convert Embed into using Components v2, for displaying Menu in :)
+    //    NOTE: I'm not converting the Preview shown during editing yet as I figure that would be easier to do via a web dashboard in future
+    
+    // Menu Details
+    let menuDetailsComponents = [
+        // Menu Title
+        {
+            "id": 2,
+            "type": ComponentType.TextDisplay,
+            "content": `## ${MenuCache.menuEmbed.data.title}`
+        }
+    ];
+    // Menu Description
+    if ( MenuCache.menuEmbed.data.description != undefined ) {
+        menuDetailsComponents.push({ "id": 3, "type": ComponentType.TextDisplay, "content": MenuCache.menuEmbed.data.description });
+    }
+    // Menu Role List
+    let menuRoleList = "";
+    menuRoleList += MenuCache.menuEmbed.data.fields.shift().value;
+    if ( MenuCache.menuEmbed.data.fields?.length > 0 ) { menuRoleList += `\n${MenuCache.menuEmbed.data.fields.shift().value}`; }
+    menuDetailsComponents.push({ "id": 4, "type": ComponentType.TextDisplay, "content": menuRoleList });
+    // Menu Requirements
+    if ( menuRequirements.length > 0 ) {
+        menuDetailsComponents.push({ "id": 5, "type": ComponentType.TextDisplay, "content": `-# ${requirementString}` });
+    }
+    // Menu Type
+    menuDetailsComponents.push({ "id": 6, "type": ComponentType.TextDisplay, "content": `-# ${MenuCache.menuEmbed.data.footer?.text}` });
+
+    // Add Action Row with Role Buttons
+    menuDetailsComponents.push(roleButtons);
+    
+
+    let convertToComponents = {
+        "id": 1,
+        "type": ComponentType.Container,
+        "accent_color": MenuCache.menuEmbed.data.color != undefined ? MenuCache.menuEmbed.data.color : null,
+        "spoiler": false,
+        "components": menuDetailsComponents
+    };
 
 
     // Post Menu
@@ -302,8 +339,7 @@ async function saveAndDisplay(interaction) {
             Authorization: `Bot ${DISCORD_TOKEN}`
         },
         body: JSON.stringify({
-            content: requirementString,
-            embeds: [embedJson],
+            flags: MessageFlags.IsComponentsV2,
             components: roleButtons,
             allowed_mentions: { parse: [] }
         })

--- a/Interactions/Selects/RoleMenus/create-role-menu.js
+++ b/Interactions/Selects/RoleMenus/create-role-menu.js
@@ -64,7 +64,7 @@ export const Select = {
 
         // Grab selected value & User ID
         const InputOption = interaction.data.values.shift();
-        const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+        const UserId = interaction.member.user.id;
 
         switch (InputOption) {
             // Set Menu Type
@@ -267,28 +267,8 @@ async function saveAndDisplay(interaction) {
     }
 
 
-    // Redo Buttons into Rows so that Discord's API won't give me a 400 response :S
-    const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+    const UserId = interaction.member.user.id;
     const MenuCache = UtilityCollections.RoleMenuManagement.get(UserId);
-
-    let roleButtons = [];
-    let temp = new ActionRowBuilder();
-
-    MenuCache.menuButtons.forEach(rButton => {
-        if ( temp.components.length === 5 ) {
-            roleButtons.push(temp.toJSON());
-            temp.setComponents([ rButton ]);
-        }
-        else {
-            temp.addComponents([ rButton ]);
-        }
-
-        // If last Button, force-push back into Array
-        let checkIndex = MenuCache.menuButtons.findIndex(theButton => theButton.data.custom_id === `role_${rButton.data.custom_id.split("_").pop()}`);
-        if ( MenuCache.menuButtons.length - 1 === checkIndex ) {
-            roleButtons.push(temp.toJSON());
-        }
-    });
 
     // Convert Embed into using Components v2, for displaying Menu in :)
     //    NOTE: I'm not converting the Preview shown during editing yet as I figure that would be easier to do via a web dashboard in future
@@ -318,8 +298,24 @@ async function saveAndDisplay(interaction) {
     // Menu Type
     menuDetailsComponents.push({ "id": 6, "type": ComponentType.TextDisplay, "content": `-# ${MenuCache.menuEmbed.data.footer?.text}` });
 
-    // Add Action Row with Role Buttons
-    menuDetailsComponents.push(roleButtons);
+    // Redo Buttons into Rows so that Discord's API won't give me a 400 response :S
+    let temp = new ActionRowBuilder();
+
+    MenuCache.menuButtons.forEach(rButton => {
+        if ( temp.components.length === 5 ) {
+            menuDetailsComponents.push(temp.toJSON());
+            temp.setComponents([ rButton ]);
+        }
+        else {
+            temp.addComponents([ rButton ]);
+        }
+
+        // If last Button, force-push back into Array
+        let checkIndex = MenuCache.menuButtons.findIndex(theButton => theButton.data.custom_id === `role_${rButton.data.custom_id.split("_").pop()}`);
+        if ( MenuCache.menuButtons.length - 1 === checkIndex ) {
+            menuDetailsComponents.push(temp.toJSON());
+        }
+    });
     
 
     let convertToComponents = {
@@ -340,7 +336,7 @@ async function saveAndDisplay(interaction) {
         },
         body: JSON.stringify({
             flags: MessageFlags.IsComponentsV2,
-            components: convertToComponents,
+            components: [convertToComponents],
             allowed_mentions: { parse: [] }
         })
     });

--- a/Interactions/Selects/RoleMenus/menu-add-requirement.js
+++ b/Interactions/Selects/RoleMenus/menu-add-requirement.js
@@ -31,7 +31,7 @@ export const Select = {
         const InputRoleId = interaction.data.values.shift();
 
         // Validate Role isn't already added as a Requirement
-        const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+        const UserId = interaction.member.user.id;
         let menuCache = UtilityCollections.RoleMenuManagement.get(UserId);
 
         if ( menuCache.roleRequirements.includes(InputRoleId) ) {

--- a/Interactions/Selects/RoleMenus/menu-add-role.js
+++ b/Interactions/Selects/RoleMenus/menu-add-role.js
@@ -33,7 +33,7 @@ export const Select = {
         const InputRoleId = interaction.data.values.pop();
 
         // Fetch current Menu
-        const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+        const UserId = interaction.member.user.id;
         let originalResponse = UtilityCollections.RoleMenuManagement.get(UserId);
         
         // Validate selected Role isn't already on this Menu

--- a/Interactions/Selects/RoleMenus/menu-remove-requirement.js
+++ b/Interactions/Selects/RoleMenus/menu-remove-requirement.js
@@ -31,7 +31,7 @@ export const Select = {
         const InputRoleId = interaction.data.values.shift();
 
         // Validate Role is added as a Requirement
-        const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+        const UserId = interaction.member.user.id;
         let menuCache = UtilityCollections.RoleMenuManagement.get(UserId);
 
         if ( !menuCache.roleRequirements.includes(InputRoleId) ) {

--- a/Interactions/Selects/RoleMenus/menu-remove-role.js
+++ b/Interactions/Selects/RoleMenus/menu-remove-role.js
@@ -32,7 +32,7 @@ export const Select = {
         const InputRoleId = interaction.data.values.shift();
 
         // Validate selected Role *is* on Menu
-        const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+        const UserId = interaction.member.user.id;
         let menuCache = UtilityCollections.RoleMenuManagement.get(UserId);
         let doesRoleExistOnMenu = false;
 

--- a/Interactions/Selects/RoleMenus/menu-set-type.js
+++ b/Interactions/Selects/RoleMenus/menu-set-type.js
@@ -28,7 +28,7 @@ export const Select = {
      */
     async executeSelect(interaction, interactionUser) {
         // Grab needed stuff
-        const UserId = interaction.member != undefined ? interaction.member?.user.id : interaction.user?.id;
+        const UserId = interaction.member.user.id;
         let originalResponse = UtilityCollections.RoleMenuManagement.get(UserId);
         const InputMenuType = interaction.data.values.shift();
 

--- a/Modules/ActionModule.js
+++ b/Modules/ActionModule.js
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, InteractionResponseType } from 'discord-api-types/v10';
+import { ApplicationCommandOptionType, ComponentType, InteractionResponseType, MessageFlags } from 'discord-api-types/v10';
 import { EmbedBuilder } from '@discordjs/builders';
 import { ActionGifs } from '../Assets/ActionGifLinks.js';
 import { localize } from '../Utility/localizeResponses.js';
@@ -141,17 +141,41 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
     }
 
     if ( wasGifRequested ) {
-        const GifEmbed = new EmbedBuilder()
+        /* const GifEmbed = new EmbedBuilder()
             .setDescription(displayMessage)
             .setImage(ActionGifs[interaction.data.name][Math.floor(( Math.random() * ActionGifs[interaction.data.name].length ) + 0)])
             .setColor(interaction.data.resolved.roles?.[InputTarget.value] != undefined ? interaction.data.resolved.roles[InputTarget.value].color : null);
 
-        let embedJson = GifEmbed.toJSON();
+        let embedJson = GifEmbed.toJSON(); */
+
+        // Try out Components v2
+        let gifComponent = {
+            "id": 1,
+            "type": ComponentType.Section,
+            "components": [
+                {
+                    "id": 2,
+                    "type": ComponentType.TextDisplay,
+                    "content": displayMessage
+                }
+            ],
+            "accessory": {
+                "id": 3,
+                "type": ComponentType.Thumbnail,
+                "media": {
+                    "url": ActionGifs[interaction.data.name][Math.floor(( Math.random() * ActionGifs[interaction.data.name].length ) + 0)]
+                },
+                "spoiler": false
+            }
+        };
 
         return new JsonResponse({
             type: InteractionResponseType.ChannelMessageWithSource,
             data: {
-                embeds: [embedJson]
+                //embeds: [embedJson]
+                flags: MessageFlags.IsComponentsV2,
+                components: [gifComponent],
+                allowed_mentions: { parse: [], users: ['159985870458322944'] }
             }
         });
     }
@@ -159,17 +183,26 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
     else {
         // Embed was force-enabled
         if ( forceDisplayEmbed ) {
-            const ActionEmbed = new EmbedBuilder()
+            /* const ActionEmbed = new EmbedBuilder()
                 .setDescription(displayMessage)
                 .setColor(interaction.data.resolved.roles?.[InputTarget.value] != undefined ? interaction.data.resolved.roles[InputTarget.value].color : null);
             
-            let actionEmbedJson = ActionEmbed.toJSON();
+            let actionEmbedJson = ActionEmbed.toJSON(); */
+
+            // Try out Components v2
+            let actionComponent = {
+                "id": 1,
+                "type": ComponentType.TextDisplay,
+                "content": displayMessage
+            }
 
             return new JsonResponse({
                 type: InteractionResponseType.ChannelMessageWithSource,
                 data: {
-                    allowed_mentions: { parse: [], users: ['159985870458322944'] },
-                    embeds: [actionEmbedJson]
+                    //embeds: [actionEmbedJson],
+                    flags: MessageFlags.IsComponentsV2,
+                    components: [actionComponent],
+                    allowed_mentions: { parse: [], users: ['159985870458322944'] }
                 }
             });
         }
@@ -178,8 +211,8 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
             return new JsonResponse({
                 type: InteractionResponseType.ChannelMessageWithSource,
                 data: {
-                    allowed_mentions: { parse: [], users: ['159985870458322944'] },
-                    content: displayMessage
+                    content: displayMessage,
+                    allowed_mentions: { parse: [], users: ['159985870458322944'] }
                 }
             });
         }

--- a/Modules/ActionModule.js
+++ b/Modules/ActionModule.js
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, ComponentType, InteractionResponseType, MessageFlags } from 'discord-api-types/v10';
+import { ApplicationCommandOptionType, ButtonStyle, ComponentType, InteractionResponseType, MessageFlags } from 'discord-api-types/v10';
 import { EmbedBuilder } from '@discordjs/builders';
 import { ActionGifs } from '../Assets/ActionGifLinks.js';
 import { localize } from '../Utility/localizeResponses.js';
@@ -69,8 +69,12 @@ function TestForRoleMention(string, slice) {
 export async function handleActionSlashCommand(interaction, interactionUser, usedCommandName) {
     // Grab input options
     const InputTarget = interaction.data.options.find(option => option.type === ApplicationCommandOptionType.Mentionable);
-    const InputIncludeGif = interaction.data.options.find(option => option.type === ApplicationCommandOptionType.Boolean);
+    //const InputIncludeGif = interaction.data.options.find(option => option.type === ApplicationCommandOptionType.Boolean);
+    /** @type {import('discord-api-types/v10').APIApplicationCommandInteractionDataBooleanOption|undefined}*/
+    const InputIncludeGif = interaction.data.options.find(option => option.name === "include-gif");
     const InputReason = interaction.data.options.find(option => option.type === ApplicationCommandOptionType.String);
+    /** @type {import('discord-api-types/v10').APIApplicationCommandInteractionDataBooleanOption|undefined}*/
+    const InputBlockReturn = interaction.data.options.find(option => option.name === "block-return");
 
     // Just for ease
     const InteractionTriggeringUserId = interaction.member != undefined ? interaction.member.user.id : interaction.user.id;
@@ -85,6 +89,19 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
     let forceDisplayEmbed = false;
     // For assembling the displayed message content
     let displayMessage = "";
+
+    // Create Return Action button, for when it is allowed to be included in response
+    let returnActionComponent = {
+        "id": 10,
+        "type": ComponentType.ActionRow,
+        "components": [{
+            "id": 11,
+            "type": ComponentType.Button,
+            "style": ButtonStyle.Primary,
+            "label": localize(interaction.guild_locale != undefined ? interaction.guild_locale : interaction.locale, `ACTION_RETURN_BUTTON_LABEL_${interaction.data.name.toUpperCase()}`),
+            "custom_id": `return-action_${interaction.data.name.toUpperCase()}_${interaction.InteractionTriggeringUserId}_${InputTarget.value}`
+        }]
+    };
 
 
     // atEveryone
@@ -151,23 +168,36 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
         // Try out Components v2
         let gifComponent = {
             "id": 1,
-            "type": ComponentType.Section,
+            "type": ComponentType.Container,
+            "accent_color": interaction.data.resolved.roles?.[InputTarget.value] != undefined ? interaction.data.resolved.roles[InputTarget.value].color : null,
+            "spoiler": false,
             "components": [
                 {
                     "id": 2,
-                    "type": ComponentType.TextDisplay,
-                    "content": displayMessage
+                    "type": ComponentType.Section,
+                    "components": [
+                        {
+                            "id": 3,
+                            "type": ComponentType.TextDisplay,
+                            "content": displayMessage
+                        }
+                    ],
+                    "accessory": {
+                        "id": 4,
+                        "type": ComponentType.Thumbnail,
+                        "media": {
+                            "url": ActionGifs[interaction.data.name][Math.floor(( Math.random() * ActionGifs[interaction.data.name].length ) + 0)]
+                        },
+                        "spoiler": false
+                    }
                 }
-            ],
-            "accessory": {
-                "id": 3,
-                "type": ComponentType.Thumbnail,
-                "media": {
-                    "url": ActionGifs[interaction.data.name][Math.floor(( Math.random() * ActionGifs[interaction.data.name].length ) + 0)]
-                },
-                "spoiler": false
-            }
+            ]
         };
+
+        // Check for Return Action button allowance
+        if ( InputBlockReturn == undefined || (InputBlockReturn != undefined && InputBlockReturn.value === true) ) {
+            gifComponent.components.push(returnActionComponent);
+        }
 
         return new JsonResponse({
             type: InteractionResponseType.ChannelMessageWithSource,
@@ -192,8 +222,21 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
             // Try out Components v2
             let actionComponent = {
                 "id": 1,
-                "type": ComponentType.TextDisplay,
-                "content": displayMessage
+                "type": ComponentType.Container,
+                "accent_color": interaction.data.resolved.roles?.[InputTarget.value] != undefined ? interaction.data.resolved.roles[InputTarget.value].color : null,
+                "spoiler": false,
+                "components": [
+                    {
+                        "id": 2,
+                        "type": ComponentType.TextDisplay,
+                        "content": displayMessage
+                    }
+                ]
+            };
+
+            // Check for Return Action button allowance
+            if ( InputBlockReturn == undefined || (InputBlockReturn != undefined && InputBlockReturn.value === true) ) {
+                actionComponent.components.push(returnActionComponent);
             }
 
             return new JsonResponse({
@@ -212,7 +255,8 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
                 type: InteractionResponseType.ChannelMessageWithSource,
                 data: {
                     content: displayMessage,
-                    allowed_mentions: { parse: [], users: ['159985870458322944'] }
+                    allowed_mentions: { parse: [], users: ['159985870458322944'] },
+                    components: ( InputBlockReturn == undefined || (InputBlockReturn != undefined && InputBlockReturn.value === true) ) ? [returnActionComponent] : undefined
                 }
             });
         }

--- a/Modules/ActionModule.js
+++ b/Modules/ActionModule.js
@@ -69,7 +69,6 @@ function TestForRoleMention(string, slice) {
 export async function handleActionSlashCommand(interaction, interactionUser, usedCommandName) {
     // Grab input options
     const InputTarget = interaction.data.options.find(option => option.type === ApplicationCommandOptionType.Mentionable);
-    //const InputIncludeGif = interaction.data.options.find(option => option.type === ApplicationCommandOptionType.Boolean);
     /** @type {import('discord-api-types/v10').APIApplicationCommandInteractionDataBooleanOption|undefined}*/
     const InputIncludeGif = interaction.data.options.find(option => option.name === "include-gif");
     const InputReason = interaction.data.options.find(option => option.type === ApplicationCommandOptionType.String);
@@ -158,14 +157,7 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
     }
 
     if ( wasGifRequested ) {
-        /* const GifEmbed = new EmbedBuilder()
-            .setDescription(displayMessage)
-            .setImage(ActionGifs[interaction.data.name][Math.floor(( Math.random() * ActionGifs[interaction.data.name].length ) + 0)])
-            .setColor(interaction.data.resolved.roles?.[InputTarget.value] != undefined ? interaction.data.resolved.roles[InputTarget.value].color : null);
-
-        let embedJson = GifEmbed.toJSON(); */
-
-        // Try out Components v2
+        // Create Components v2 response
         let gifComponent = {
             "id": 1,
             "type": ComponentType.Container,
@@ -202,7 +194,6 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
         return new JsonResponse({
             type: InteractionResponseType.ChannelMessageWithSource,
             data: {
-                //embeds: [embedJson]
                 flags: MessageFlags.IsComponentsV2,
                 components: [gifComponent],
                 allowed_mentions: { parse: [], users: ['159985870458322944'] }
@@ -213,13 +204,7 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
     else {
         // Embed was force-enabled
         if ( forceDisplayEmbed ) {
-            /* const ActionEmbed = new EmbedBuilder()
-                .setDescription(displayMessage)
-                .setColor(interaction.data.resolved.roles?.[InputTarget.value] != undefined ? interaction.data.resolved.roles[InputTarget.value].color : null);
-            
-            let actionEmbedJson = ActionEmbed.toJSON(); */
-
-            // Try out Components v2
+            // Create Components v2 response
             let actionComponent = {
                 "id": 1,
                 "type": ComponentType.Container,
@@ -242,7 +227,6 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
             return new JsonResponse({
                 type: InteractionResponseType.ChannelMessageWithSource,
                 data: {
-                    //embeds: [actionEmbedJson],
                     flags: MessageFlags.IsComponentsV2,
                     components: [actionComponent],
                     allowed_mentions: { parse: [], users: ['159985870458322944'] }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Just some fun little roleplay-style Commands (such as `/bonk`, `/hug`, `/boop`, 
 
 Some Action Commands can also be used via right-clicking/long-pressing on a User! These "User Command" variants exist for those who just want a quicker way of giving someone a Bonk, Boop, or Headpat. :)
 
+The Action Slash Commands also display a "return action" button when used. This can be prevented by setting the "`block-return`" option to `True` when using the Slash Command.
+
 ## Role Menus
 > [!NOTE]
 > The Role Menu management Commands can only be used within Servers, meaning TwiLite has to be added to the Server in question in order for its Role Menu Commands to function.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ There are two ways to convert temperatures using TwiLite:
 |------------|-------------|-------------|
 | `/temperature` | Slash | Convert a single temperature between degrees C, F, and K |
 | "`Convert Temperature`" | Message | Convert up to 10 temperatures at once from a single Message |
+| `/add-app` | Slash | Shows you the Add App/Invite link you can use to add TwiLite to either your Server(s) or your Account |
+| `/support` | Slash | Shows you where you can gain support from TwiLite's developer, or post ideas/bug reports for TwiLite |
+| `/follow-news` | Slash | Adds TwiLite's Updates & Announcements Feed to the Channel you used this Command in |
 
 ## Command Type Notes
 - "Message" refers to Message Context Commands

--- a/Utility/interactions.js
+++ b/Utility/interactions.js
@@ -37,6 +37,9 @@ export const Autocompletes = {
 }
 
 export const Buttons = {
+    // ***** FOR ACTION MODULE
+    'return-action': () => import('../Interactions/Buttons/Actions/return-action.js'),
+
     // ***** FOR ROLE MENUS
     'role': () => import('../Interactions/Buttons/RoleMenus/role.js'),
     'menu-delete': () => import('../Interactions/Buttons/RoleMenus/menu-delete.js'),

--- a/Utility/utilityConstants.js
+++ b/Utility/utilityConstants.js
@@ -29,7 +29,7 @@ export const UtilityCollections = {
     SelectCooldowns: new Collection(),
 
     /** Temp-stores Interaction IDs && Tokens for use in editing/deleting messages during Role Menu Management. Also caches Buttons & Embed during Menu management.
-     *  Collection<userId, {sourceMessageId, interactionId, interactionToken, selectMenu, menuEmbed, menuButtons, roleRequirements, mainInstructions}>
+     *  `Collection<userId, {sourceMessageId, interactionId, interactionToken, selectMenu, menuEmbed, menuButtons, roleRequirements, mainInstructions}>`
      * @type {Collection<String, {sourceMessageId: ?String, interactionId: String, interactionToken: String, selectMenu: ActionRowBuilder, menuEmbed: EmbedBuilder, menuButtons: Array<ButtonBuilder>, roleRequirements: Array<String>, mainInstructions: String}>}
      */
     RoleMenuManagement: new Collection()
@@ -71,12 +71,12 @@ export const SystemMessageTypes = [
     45, // VOICE_HANGOUT_INVITE - Either deprecated or was a scrapped experiment?
     47, // CHANGELOG - Used only TWICE before being scrapped due to r/discordapp complaints. Zebby liked having Discord Changelogs in System DMs, but whatever...
     48, // NITRO_NOTIFICATION - Has this ever been used? 
-    49, // CHANNEL_LINKED_TO_LOBBY - Behind an experiment currently
+    49, // CHANNEL_LINKED_TO_LOBBY - Behind an experiment currently (SocialSDK)
     50, // GIFTING_PROMPT - Part of the Friendship Anniversary Experiment
-    51, // IN_GAME_MESSAGE_NUX - Behind an experiment currently
-    52, // GUILD_JOIN_REQUEST_ACCEPT_NOTIFICATION - Not yet added to D-API-Types (part of Membership Screening v2, which was revived for Gaming Guilds)
-    53, // GUILD_JOIN_REQUEST_REJECT_NOTIFICATION - Not yet added to D-API-Types (part of Membership Screening v2, which was revived for Gaming Guilds)
-    54, // GUILD_JOIN_REQUEST_WITHDRAWN_NOTIFICATION - Not yet added to D-API-Types (part of Membership Screening v2, which was revived for Gaming Guilds)
+    51, // IN_GAME_MESSAGE_NUX - Behind an experiment currently (SocialSDK)
+    52, // GUILD_JOIN_REQUEST_ACCEPT_NOTIFICATION - Not yet added to D-API-Types (part of Server Membership Applications)
+    53, // GUILD_JOIN_REQUEST_REJECT_NOTIFICATION - Not yet added to D-API-Types (part of Server Membership Applications)
+    54, // GUILD_JOIN_REQUEST_WITHDRAWN_NOTIFICATION - Not yet added to D-API-Types (part of Server Membership Applications)
     55, // HD_STREAMING_UPGRADED - Part of the HD Splash Potion Experiment (or has it fully released now?)
 ];
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "undici": "^7.3.0"
   },
   "devDependencies": {
-    "wrangler": "^3.111.0"
+    "wrangler": "^4.12.0"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@discordjs/builders": "^1.10.1",
     "@discordjs/collection": "^2.1.1",
-    "discord-api-types": "0.38.0-next-1739718635626",
+    "discord-api-types": "0.38.0-next-1740095508888",
     "discord-interactions": "^4.1.0",
     "emoji-regex": "^10.4.0",
     "itty-router": "^5.0.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       discord-api-types:
-        specifier: 0.38.0-next-1739718635626
-        version: 0.38.0-next-1739718635626
+        specifier: 0.38.0-next-1740095508888
+        version: 0.38.0-next-1740095508888
       discord-interactions:
         specifier: ^4.1.0
         version: 4.1.1
@@ -429,8 +429,8 @@ packages:
   discord-api-types@0.37.119:
     resolution: {integrity: sha512-WasbGFXEB+VQWXlo6IpW3oUv73Yuau1Ig4AZF/m13tXcTKnMpc/mHjpztIlz4+BM9FG9BHQkEXiPto3bKduQUg==, tarball: https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.119.tgz}
 
-  discord-api-types@0.38.0-next-1739718635626:
-    resolution: {integrity: sha512-ypUbZYP+uglWOwwzQl3Akhz9pzGf6gNB4qxPqPDFBFApdJQtKpkW1dmXytiBUtbslSRjsudPEaRk1y0/gS0psw==, tarball: https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.0-next-1739718635626.tgz}
+  discord-api-types@0.38.0-next-1740095508888:
+    resolution: {integrity: sha512-J9ZpbCe8sO/TJIhjUdrfZmR+VPqD/x0WzkiAv4u6H/4Cazo0nE3lYU31wRFbaiXDKcw6+hUjkVVfp5dWLrGdNA==, tarball: https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.0-next-1740095508888.tgz}
 
   discord-interactions@4.1.1:
     resolution: {integrity: sha512-dCrdJFSHQrEHXB8tk+LpIhAL7/+/UXCFDzooYmB6jj7b/zuhdbETpcZXLYQpSfcSRpF5wjmnu1XwuHlvdF1KpQ==, tarball: https://registry.npmjs.org/discord-interactions/-/discord-interactions-4.1.1.tgz}
@@ -873,7 +873,7 @@ snapshots:
 
   discord-api-types@0.37.119: {}
 
-  discord-api-types@0.38.0-next-1739718635626: {}
+  discord-api-types@0.38.0-next-1740095508888: {}
 
   discord-interactions@4.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,41 +35,50 @@ importers:
         version: 7.3.0
     devDependencies:
       wrangler:
-        specifier: ^3.111.0
-        version: 3.111.0
+        specifier: ^4.12.0
+        version: 4.12.0
 
 packages:
 
-  '@cloudflare/kv-asset-handler@0.3.4':
-    resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==, tarball: https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz}
-    engines: {node: '>=16.13'}
+  '@cloudflare/kv-asset-handler@0.4.0':
+    resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==, tarball: https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.0.tgz}
+    engines: {node: '>=18.0.0'}
 
-  '@cloudflare/workerd-darwin-64@1.20250214.0':
-    resolution: {integrity: sha512-cDvvedWDc5zrgDnuXe2qYcz/TwBvzmweO55C7XpPuAWJ9Oqxv81PkdekYxD8mH989aQ/GI5YD0Fe6fDYlM+T3Q==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250214.0.tgz}
+  '@cloudflare/unenv-preset@2.3.1':
+    resolution: {integrity: sha512-Xq57Qd+ADpt6hibcVBO0uLG9zzRgyRhfCUgBT9s+g3+3Ivg5zDyVgLFy40ES1VdNcu8rPNSivm9A+kGP5IVaPg==, tarball: https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.3.1.tgz}
+    peerDependencies:
+      unenv: 2.0.0-rc.15
+      workerd: ^1.20250320.0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20250416.0':
+    resolution: {integrity: sha512-aZgF8Swp9eVYxJPWOoZbAgAaYjWuYqGmEA+QJ2ecRGDBqm87rT4GEw7/mmLpxrpllny3VfEEhkk9iYCGv8nlFw==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250416.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20250214.0':
-    resolution: {integrity: sha512-NytCvRveVzu0mRKo+tvZo3d/gCUway3B2ZVqSi/TS6NXDGBYIJo7g6s3BnTLS74kgyzeDOjhu9j/RBJBS809qw==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250214.0.tgz}
+  '@cloudflare/workerd-darwin-arm64@1.20250416.0':
+    resolution: {integrity: sha512-FhswG1QYRfaTZ4FAlUkfVWaoM2lrlqumiBTrhbo9czMJdGR/oBXS4SGynuI6zyhApHeBf3/fZpA/SBAe4cXdgg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250416.0.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20250214.0':
-    resolution: {integrity: sha512-pQ7+aHNHj8SiYEs4d/6cNoimE5xGeCMfgU1yfDFtA9YGN9Aj2BITZgOWPec+HW7ZkOy9oWlNrO6EvVjGgB4tbQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250214.0.tgz}
+  '@cloudflare/workerd-linux-64@1.20250416.0':
+    resolution: {integrity: sha512-G+nXEAJ/9y+A857XShwxKeRdfxok6UcjiQe6G+wQeCn/Ofkp/EWydacKdyeVU6QIm1oHS78DwJ7AzbCYywf9aw==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250416.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20250214.0':
-    resolution: {integrity: sha512-Vhlfah6Yd9ny1npNQjNgElLIjR6OFdEbuR3LCfbLDCwzWEBFhIf7yC+Tpp/a0Hq7kLz3sLdktaP7xl3PJhyOjA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250214.0.tgz}
+  '@cloudflare/workerd-linux-arm64@1.20250416.0':
+    resolution: {integrity: sha512-U6oVW0d9w1fpnDYNrjPJ9SFkDlGJWJWbXHlTBObXl6vccP16WewvuxyHkKqyUhUc8hyBaph7sxeKzKmuCFQ4SA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250416.0.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20250214.0':
-    resolution: {integrity: sha512-GMwMyFbkjBKjYJoKDhGX8nuL4Gqe3IbVnVWf2Q6086CValyIknupk5J6uQWGw2EBU3RGO3x4trDXT5WphQJZDQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250214.0.tgz}
+  '@cloudflare/workerd-windows-64@1.20250416.0':
+    resolution: {integrity: sha512-YAjjTzL1z9YYeN4sqYfj1dtQXd2Bblj+B+hl4Rz2aOhblpZEZAdhapZlOCRvLLkOJshKJUnRD3mDlytAdgwybQ==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250416.0.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -97,162 +106,152 @@ packages:
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==, tarball: https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz}
 
-  '@esbuild-plugins/node-globals-polyfill@0.2.3':
-    resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==, tarball: https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz}
-    peerDependencies:
-      esbuild: '>=0.25.0'
-
-  '@esbuild-plugins/node-modules-polyfill@0.2.2':
-    resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==, tarball: https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz}
-    peerDependencies:
-      esbuild: '>=0.25.0'
-
-  '@esbuild/aix-ppc64@0.25.0':
-    resolution: {integrity: sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==, tarball: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz}
+  '@esbuild/aix-ppc64@0.25.2':
+    resolution: {integrity: sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==, tarball: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.0':
-    resolution: {integrity: sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz}
+  '@esbuild/android-arm64@0.25.2':
+    resolution: {integrity: sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.0':
-    resolution: {integrity: sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz}
+  '@esbuild/android-arm@0.25.2':
+    resolution: {integrity: sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.0':
-    resolution: {integrity: sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz}
+  '@esbuild/android-x64@0.25.2':
+    resolution: {integrity: sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.0':
-    resolution: {integrity: sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz}
+  '@esbuild/darwin-arm64@0.25.2':
+    resolution: {integrity: sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.0':
-    resolution: {integrity: sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz}
+  '@esbuild/darwin-x64@0.25.2':
+    resolution: {integrity: sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.0':
-    resolution: {integrity: sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz}
+  '@esbuild/freebsd-arm64@0.25.2':
+    resolution: {integrity: sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.0':
-    resolution: {integrity: sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz}
+  '@esbuild/freebsd-x64@0.25.2':
+    resolution: {integrity: sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.0':
-    resolution: {integrity: sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz}
+  '@esbuild/linux-arm64@0.25.2':
+    resolution: {integrity: sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.0':
-    resolution: {integrity: sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz}
+  '@esbuild/linux-arm@0.25.2':
+    resolution: {integrity: sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.0':
-    resolution: {integrity: sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz}
+  '@esbuild/linux-ia32@0.25.2':
+    resolution: {integrity: sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.0':
-    resolution: {integrity: sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz}
+  '@esbuild/linux-loong64@0.25.2':
+    resolution: {integrity: sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.0':
-    resolution: {integrity: sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz}
+  '@esbuild/linux-mips64el@0.25.2':
+    resolution: {integrity: sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.0':
-    resolution: {integrity: sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz}
+  '@esbuild/linux-ppc64@0.25.2':
+    resolution: {integrity: sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.0':
-    resolution: {integrity: sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz}
+  '@esbuild/linux-riscv64@0.25.2':
+    resolution: {integrity: sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.0':
-    resolution: {integrity: sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz}
+  '@esbuild/linux-s390x@0.25.2':
+    resolution: {integrity: sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.0':
-    resolution: {integrity: sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz}
+  '@esbuild/linux-x64@0.25.2':
+    resolution: {integrity: sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.0':
-    resolution: {integrity: sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==, tarball: https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz}
+  '@esbuild/netbsd-arm64@0.25.2':
+    resolution: {integrity: sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==, tarball: https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.0':
-    resolution: {integrity: sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz}
+  '@esbuild/netbsd-x64@0.25.2':
+    resolution: {integrity: sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.0':
-    resolution: {integrity: sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==, tarball: https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz}
+  '@esbuild/openbsd-arm64@0.25.2':
+    resolution: {integrity: sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==, tarball: https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.0':
-    resolution: {integrity: sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz}
+  '@esbuild/openbsd-x64@0.25.2':
+    resolution: {integrity: sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.25.0':
-    resolution: {integrity: sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz}
+  '@esbuild/sunos-x64@0.25.2':
+    resolution: {integrity: sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.0':
-    resolution: {integrity: sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz}
+  '@esbuild/win32-arm64@0.25.2':
+    resolution: {integrity: sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.0':
-    resolution: {integrity: sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz}
+  '@esbuild/win32-ia32@0.25.2':
+    resolution: {integrity: sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.0':
-    resolution: {integrity: sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz}
+  '@esbuild/win32-x64@0.25.2':
+    resolution: {integrity: sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -409,12 +408,9 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==, tarball: https://registry.npmjs.org/color/-/color-4.2.3.tgz}
     engines: {node: '>=12.5.0'}
 
-  confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==, tarball: https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz}
-
-  cookie@1.0.2:
-    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==, tarball: https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz}
-    engines: {node: '>=18'}
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==, tarball: https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz}
+    engines: {node: '>= 0.6'}
 
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==, tarball: https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz}
@@ -439,21 +435,17 @@ packages:
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==, tarball: https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz}
 
-  esbuild@0.25.0:
-    resolution: {integrity: sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==, tarball: https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz}
+  esbuild@0.25.2:
+    resolution: {integrity: sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==, tarball: https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz}
     engines: {node: '>=18'}
     hasBin: true
-
-  escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==, tarball: https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz}
-    engines: {node: '>=10'}
-
-  estree-walker@0.6.1:
-    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==, tarball: https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz}
 
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==, tarball: https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz}
     engines: {node: '>=6'}
+
+  exsolve@1.0.5:
+    resolution: {integrity: sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==, tarball: https://registry.npmjs.org/exsolve/-/exsolve-1.0.5.tgz}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==, tarball: https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz}
@@ -478,53 +470,31 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==, tarball: https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz}
 
-  magic-string@0.25.9:
-    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==, tarball: https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz}
-
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==, tarball: https://registry.npmjs.org/mime/-/mime-3.0.0.tgz}
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  miniflare@3.20250214.1:
-    resolution: {integrity: sha512-NE66QV+2n9ZndaP5jgPlcVref3Arvizb+l2QqhgeXtKM5Orhi8UU2mijoiN3mHEUexKaBES2S1VubT4LDPqkxQ==, tarball: https://registry.npmjs.org/miniflare/-/miniflare-3.20250214.1.tgz}
-    engines: {node: '>=16.13'}
+  miniflare@4.20250416.0:
+    resolution: {integrity: sha512-261PhPgD9zs5/BTdbWqwiaXtWxb+Av5zKCwTU+HXrA5E4tf3qnULwh3u6SVUOAEArEroFuKJzawsQ9COtNBurQ==, tarball: https://registry.npmjs.org/miniflare/-/miniflare-4.20250416.0.tgz}
+    engines: {node: '>=18.0.0'}
     hasBin: true
-
-  mlly@1.7.4:
-    resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==, tarball: https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz}
 
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==, tarball: https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz}
     hasBin: true
 
-  ohash@1.1.4:
-    resolution: {integrity: sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==, tarball: https://registry.npmjs.org/ohash/-/ohash-1.1.4.tgz}
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==, tarball: https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==, tarball: https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==, tarball: https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz}
-
-  pathe@2.0.2:
-    resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==, tarball: https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz}
-
-  pkg-types@1.3.1:
-    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==, tarball: https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz}
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==, tarball: https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz}
 
   printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==, tarball: https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz}
-
-  rollup-plugin-inject@3.0.2:
-    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==, tarball: https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz}
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
-
-  rollup-plugin-node-polyfills@0.2.1:
-    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==, tarball: https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz}
-
-  rollup-pluginutils@2.8.2:
-    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==, tarball: https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz}
 
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==, tarball: https://registry.npmjs.org/semver/-/semver-7.7.1.tgz}
@@ -541,10 +511,6 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==, tarball: https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz}
     engines: {node: '>=0.10.0'}
-
-  sourcemap-codec@1.4.8:
-    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==, tarball: https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz}
-    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   stacktracey@2.1.8:
     resolution: {integrity: sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==, tarball: https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz}
@@ -570,20 +536,20 @@ packages:
     resolution: {integrity: sha512-Qy96NND4Dou5jKoSJ2gm8ax8AJM/Ey9o9mz7KN1bb9GP+G0l20Zw8afxTnY2f4b7hmhn/z8aC2kfArVQlAhFBw==, tarball: https://registry.npmjs.org/undici/-/undici-7.3.0.tgz}
     engines: {node: '>=20.18.1'}
 
-  unenv@2.0.0-rc.1:
-    resolution: {integrity: sha512-PU5fb40H8X149s117aB4ytbORcCvlASdtF97tfls4BPIyj4PeVxvpSuy1jAptqYHqB0vb2w2sHvzM0XWcp2OKg==, tarball: https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.1.tgz}
+  unenv@2.0.0-rc.15:
+    resolution: {integrity: sha512-J/rEIZU8w6FOfLNz/hNKsnY+fFHWnu9MH4yRbSZF3xbbGHovcetXPs7sD+9p8L6CeNC//I9bhRYAOsBt2u7/OA==, tarball: https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.15.tgz}
 
-  workerd@1.20250214.0:
-    resolution: {integrity: sha512-QWcqXZLiMpV12wiaVnb3nLmfs/g4ZsFQq2mX85z546r3AX4CTIkXl0VP50W3CwqLADej3PGYiRDOTelDOwVG1g==, tarball: https://registry.npmjs.org/workerd/-/workerd-1.20250214.0.tgz}
+  workerd@1.20250416.0:
+    resolution: {integrity: sha512-Yrx/bZAKbmSvomdTAzzIpOHwpYhs0ldr2wqed22UEhQ0mIplAHY4xmY+SjAJhP/TydZrciOVzBxwM1+4T40KNA==, tarball: https://registry.npmjs.org/workerd/-/workerd-1.20250416.0.tgz}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@3.111.0:
-    resolution: {integrity: sha512-3j/Wq5aj/sCQRSmkjBLxbkIH7LCx0h2UnaxmhOplDjJmZty10lGRs/jGgaG/M/GEsDg5TJ7UHvBh3hSldgjfKg==, tarball: https://registry.npmjs.org/wrangler/-/wrangler-3.111.0.tgz}
-    engines: {node: '>=16.17.0'}
+  wrangler@4.12.0:
+    resolution: {integrity: sha512-4rfAXOi5KqM3ECvOrZJ97k3zEqxVwtdt4bijd8jcRBZ6iJYvEtjgjVi4TsfkVa/eXGhpfHTUnKu2uk8UHa8M2w==, tarball: https://registry.npmjs.org/wrangler/-/wrangler-4.12.0.tgz}
+    engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20250214.0
+      '@cloudflare/workers-types': ^4.20250415.0
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -600,31 +566,37 @@ packages:
       utf-8-validate:
         optional: true
 
-  youch@3.2.3:
-    resolution: {integrity: sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==, tarball: https://registry.npmjs.org/youch/-/youch-3.2.3.tgz}
+  youch@3.3.4:
+    resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==, tarball: https://registry.npmjs.org/youch/-/youch-3.3.4.tgz}
 
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==, tarball: https://registry.npmjs.org/zod/-/zod-3.22.3.tgz}
 
 snapshots:
 
-  '@cloudflare/kv-asset-handler@0.3.4':
+  '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
       mime: 3.0.0
 
-  '@cloudflare/workerd-darwin-64@1.20250214.0':
+  '@cloudflare/unenv-preset@2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250416.0)':
+    dependencies:
+      unenv: 2.0.0-rc.15
+    optionalDependencies:
+      workerd: 1.20250416.0
+
+  '@cloudflare/workerd-darwin-64@1.20250416.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20250214.0':
+  '@cloudflare/workerd-darwin-arm64@1.20250416.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20250214.0':
+  '@cloudflare/workerd-linux-64@1.20250416.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20250214.0':
+  '@cloudflare/workerd-linux-arm64@1.20250416.0':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20250214.0':
+  '@cloudflare/workerd-windows-64@1.20250416.0':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
@@ -654,89 +626,79 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.25.0)':
-    dependencies:
-      esbuild: 0.25.0
-
-  '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.25.0)':
-    dependencies:
-      esbuild: 0.25.0
-      escape-string-regexp: 4.0.0
-      rollup-plugin-node-polyfills: 0.2.1
-
-  '@esbuild/aix-ppc64@0.25.0':
+  '@esbuild/aix-ppc64@0.25.2':
     optional: true
 
-  '@esbuild/android-arm64@0.25.0':
+  '@esbuild/android-arm64@0.25.2':
     optional: true
 
-  '@esbuild/android-arm@0.25.0':
+  '@esbuild/android-arm@0.25.2':
     optional: true
 
-  '@esbuild/android-x64@0.25.0':
+  '@esbuild/android-x64@0.25.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.0':
+  '@esbuild/darwin-arm64@0.25.2':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.0':
+  '@esbuild/darwin-x64@0.25.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.0':
+  '@esbuild/freebsd-arm64@0.25.2':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.0':
+  '@esbuild/freebsd-x64@0.25.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.0':
+  '@esbuild/linux-arm64@0.25.2':
     optional: true
 
-  '@esbuild/linux-arm@0.25.0':
+  '@esbuild/linux-arm@0.25.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.0':
+  '@esbuild/linux-ia32@0.25.2':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.0':
+  '@esbuild/linux-loong64@0.25.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.0':
+  '@esbuild/linux-mips64el@0.25.2':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.0':
+  '@esbuild/linux-ppc64@0.25.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.0':
+  '@esbuild/linux-riscv64@0.25.2':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.0':
+  '@esbuild/linux-s390x@0.25.2':
     optional: true
 
-  '@esbuild/linux-x64@0.25.0':
+  '@esbuild/linux-x64@0.25.2':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.0':
+  '@esbuild/netbsd-arm64@0.25.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.0':
+  '@esbuild/netbsd-x64@0.25.2':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.0':
+  '@esbuild/openbsd-arm64@0.25.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.0':
+  '@esbuild/openbsd-x64@0.25.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.0':
+  '@esbuild/sunos-x64@0.25.2':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.0':
+  '@esbuild/win32-arm64@0.25.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.0':
+  '@esbuild/win32-ia32@0.25.2':
     optional: true
 
-  '@esbuild/win32-x64@0.25.0':
+  '@esbuild/win32-x64@0.25.2':
     optional: true
 
   '@fastify/busboy@2.1.1': {}
@@ -860,9 +822,7 @@ snapshots:
       color-string: 1.9.1
     optional: true
 
-  confbox@0.1.8: {}
-
-  cookie@1.0.2: {}
+  cookie@0.7.2: {}
 
   data-uri-to-buffer@2.0.2: {}
 
@@ -879,39 +839,37 @@ snapshots:
 
   emoji-regex@10.4.0: {}
 
-  esbuild@0.25.0:
+  esbuild@0.25.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.0
-      '@esbuild/android-arm': 0.25.0
-      '@esbuild/android-arm64': 0.25.0
-      '@esbuild/android-x64': 0.25.0
-      '@esbuild/darwin-arm64': 0.25.0
-      '@esbuild/darwin-x64': 0.25.0
-      '@esbuild/freebsd-arm64': 0.25.0
-      '@esbuild/freebsd-x64': 0.25.0
-      '@esbuild/linux-arm': 0.25.0
-      '@esbuild/linux-arm64': 0.25.0
-      '@esbuild/linux-ia32': 0.25.0
-      '@esbuild/linux-loong64': 0.25.0
-      '@esbuild/linux-mips64el': 0.25.0
-      '@esbuild/linux-ppc64': 0.25.0
-      '@esbuild/linux-riscv64': 0.25.0
-      '@esbuild/linux-s390x': 0.25.0
-      '@esbuild/linux-x64': 0.25.0
-      '@esbuild/netbsd-arm64': 0.25.0
-      '@esbuild/netbsd-x64': 0.25.0
-      '@esbuild/openbsd-arm64': 0.25.0
-      '@esbuild/openbsd-x64': 0.25.0
-      '@esbuild/sunos-x64': 0.25.0
-      '@esbuild/win32-arm64': 0.25.0
-      '@esbuild/win32-ia32': 0.25.0
-      '@esbuild/win32-x64': 0.25.0
-
-  escape-string-regexp@4.0.0: {}
-
-  estree-walker@0.6.1: {}
+      '@esbuild/aix-ppc64': 0.25.2
+      '@esbuild/android-arm': 0.25.2
+      '@esbuild/android-arm64': 0.25.2
+      '@esbuild/android-x64': 0.25.2
+      '@esbuild/darwin-arm64': 0.25.2
+      '@esbuild/darwin-x64': 0.25.2
+      '@esbuild/freebsd-arm64': 0.25.2
+      '@esbuild/freebsd-x64': 0.25.2
+      '@esbuild/linux-arm': 0.25.2
+      '@esbuild/linux-arm64': 0.25.2
+      '@esbuild/linux-ia32': 0.25.2
+      '@esbuild/linux-loong64': 0.25.2
+      '@esbuild/linux-mips64el': 0.25.2
+      '@esbuild/linux-ppc64': 0.25.2
+      '@esbuild/linux-riscv64': 0.25.2
+      '@esbuild/linux-s390x': 0.25.2
+      '@esbuild/linux-x64': 0.25.2
+      '@esbuild/netbsd-arm64': 0.25.2
+      '@esbuild/netbsd-x64': 0.25.2
+      '@esbuild/openbsd-arm64': 0.25.2
+      '@esbuild/openbsd-x64': 0.25.2
+      '@esbuild/sunos-x64': 0.25.2
+      '@esbuild/win32-arm64': 0.25.2
+      '@esbuild/win32-ia32': 0.25.2
+      '@esbuild/win32-x64': 0.25.2
 
   exit-hook@2.2.1: {}
+
+  exsolve@1.0.5: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -932,13 +890,9 @@ snapshots:
 
   lodash@4.17.21: {}
 
-  magic-string@0.25.9:
-    dependencies:
-      sourcemap-codec: 1.4.8
-
   mime@3.0.0: {}
 
-  miniflare@3.20250214.1:
+  miniflare@4.20250416.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       acorn: 8.14.0
@@ -947,52 +901,23 @@ snapshots:
       glob-to-regexp: 0.4.1
       stoppable: 1.1.0
       undici: 5.28.5
-      workerd: 1.20250214.0
+      workerd: 1.20250416.0
       ws: 8.18.0
-      youch: 3.2.3
+      youch: 3.3.4
       zod: 3.22.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  mlly@1.7.4:
-    dependencies:
-      acorn: 8.14.0
-      pathe: 2.0.2
-      pkg-types: 1.3.1
-      ufo: 1.5.4
-
   mustache@4.2.0: {}
 
-  ohash@1.1.4: {}
+  ohash@2.0.11: {}
 
   path-to-regexp@6.3.0: {}
 
-  pathe@1.1.2: {}
-
-  pathe@2.0.2: {}
-
-  pkg-types@1.3.1:
-    dependencies:
-      confbox: 0.1.8
-      mlly: 1.7.4
-      pathe: 2.0.2
+  pathe@2.0.3: {}
 
   printable-characters@1.0.42: {}
-
-  rollup-plugin-inject@3.0.2:
-    dependencies:
-      estree-walker: 0.6.1
-      magic-string: 0.25.9
-      rollup-pluginutils: 2.8.2
-
-  rollup-plugin-node-polyfills@0.2.1:
-    dependencies:
-      rollup-plugin-inject: 3.0.2
-
-  rollup-pluginutils@2.8.2:
-    dependencies:
-      estree-walker: 0.6.1
 
   semver@7.7.1:
     optional: true
@@ -1031,8 +956,6 @@ snapshots:
 
   source-map@0.6.1: {}
 
-  sourcemap-codec@1.4.8: {}
-
   stacktracey@2.1.8:
     dependencies:
       as-table: 1.0.55
@@ -1052,33 +975,32 @@ snapshots:
 
   undici@7.3.0: {}
 
-  unenv@2.0.0-rc.1:
+  unenv@2.0.0-rc.15:
     dependencies:
       defu: 6.1.4
-      mlly: 1.7.4
-      ohash: 1.1.4
-      pathe: 1.1.2
+      exsolve: 1.0.5
+      ohash: 2.0.11
+      pathe: 2.0.3
       ufo: 1.5.4
 
-  workerd@1.20250214.0:
+  workerd@1.20250416.0:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20250214.0
-      '@cloudflare/workerd-darwin-arm64': 1.20250214.0
-      '@cloudflare/workerd-linux-64': 1.20250214.0
-      '@cloudflare/workerd-linux-arm64': 1.20250214.0
-      '@cloudflare/workerd-windows-64': 1.20250214.0
+      '@cloudflare/workerd-darwin-64': 1.20250416.0
+      '@cloudflare/workerd-darwin-arm64': 1.20250416.0
+      '@cloudflare/workerd-linux-64': 1.20250416.0
+      '@cloudflare/workerd-linux-arm64': 1.20250416.0
+      '@cloudflare/workerd-windows-64': 1.20250416.0
 
-  wrangler@3.111.0:
+  wrangler@4.12.0:
     dependencies:
-      '@cloudflare/kv-asset-handler': 0.3.4
-      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.25.0)
-      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.25.0)
+      '@cloudflare/kv-asset-handler': 0.4.0
+      '@cloudflare/unenv-preset': 2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250416.0)
       blake3-wasm: 2.1.5
-      esbuild: 0.25.0
-      miniflare: 3.20250214.1
+      esbuild: 0.25.2
+      miniflare: 4.20250416.0
       path-to-regexp: 6.3.0
-      unenv: 2.0.0-rc.1
-      workerd: 1.20250214.0
+      unenv: 2.0.0-rc.15
+      workerd: 1.20250416.0
     optionalDependencies:
       fsevents: 2.3.3
       sharp: 0.33.5
@@ -1088,9 +1010,9 @@ snapshots:
 
   ws@8.18.0: {}
 
-  youch@3.2.3:
+  youch@3.3.4:
     dependencies:
-      cookie: 1.0.2
+      cookie: 0.7.2
       mustache: 4.2.0
       stacktracey: 2.1.8
 


### PR DESCRIPTION
Adds support for Discord's Components v2 system (which adds a bunch of new Output/Display Components).

This is using Advaith's `discord-api-types` PR & [Lulalaby's public Documentation drafts](https://github.com/Lulalaby/discord-api-docs/blob/comp_v2/docs/interactions/Message_Components.md) in order to add support before Components v2 are actually released :)
(Thanks you two!)

I also took the chance to re-add the removed "Return Action" Buttons for the Action Commands in this PR.

This PR will be un-blocked when Discord actually releases Components v2 (whenever that will be).
*Yes, I did just want to get Day 1 support for Components v2* 😅 