### PR TITLE
Add requested Action CMDs

### DIFF
--- a/Assets/ActionGifLinks.js
+++ b/Assets/ActionGifLinks.js
@@ -62,7 +62,6 @@ export const ActionGifs = {
         "https://twilite.is-from.space/r/action-boop-0004.gif",
         "https://twilite.is-from.space/r/action-boop-0005.gif",
         "https://twilite.is-from.space/r/action-boop-0006.gif",
-        "https://twilite.is-from.space/r/action-boop-0007.gif",
         "https://twilite.is-from.space/r/action-boop-0008.gif",
         "https://twilite.is-from.space/r/action-boop-0009.gif",
         "https://twilite.is-from.space/r/action-boop-0010.gif",
@@ -80,7 +79,8 @@ export const ActionGifs = {
         "https://twilite.is-from.space/r/action-kiss-0007.gif",
         "https://twilite.is-from.space/r/action-kiss-0008.gif",
         "https://twilite.is-from.space/r/action-kiss-0009.gif",
-        "https://twilite.is-from.space/r/action-kiss-0010.gif"
+        "https://twilite.is-from.space/r/action-kiss-0010.gif",
+        "https://twilite.is-from.space/r/action-kiss-0011.gif",
     ],
 
     "yeet": [
@@ -97,5 +97,16 @@ export const ActionGifs = {
         "https://twilite.is-from.space/r/action-cookie-0004.gif",
         "https://twilite.is-from.space/r/action-cookie-0005.gif",
         "https://twilite.is-from.space/r/action-cookie-0006.gif"
+    ],
+
+    "slap": [
+        "https://twilite.is-from.space/r/action-slap-0001.gif",
+        "https://twilite.is-from.space/r/action-slap-0002.gif",
+        "https://twilite.is-from.space/r/action-slap-0003.gif",
+        "https://twilite.is-from.space/r/action-slap-0004.gif",
+        "https://twilite.is-from.space/r/action-slap-0005.gif",
+        "https://twilite.is-from.space/r/action-slap-0006.gif",
+        "https://twilite.is-from.space/r/action-slap-0007.gif",
+        "https://twilite.is-from.space/r/action-slap-0008.gif"
     ]
 };

--- a/Commands/ContextCommands/Actions/Kiss_User.js
+++ b/Commands/ContextCommands/Actions/Kiss_User.js
@@ -1,0 +1,106 @@
+import { ApplicationCommandType, InteractionContextType, ApplicationIntegrationType, MessageFlags, InteractionResponseType } from 'discord-api-types/v10';
+import { JsonResponse } from '../../../Utility/utilityMethods.js';
+import { localize } from '../../../Utility/localizeResponses.js';
+import { DISCORD_APP_USER_ID } from '../../../config.js';
+
+
+export const ContextCommand = {
+    /** Command's Name, supports both upper- and lower-case, and spaces
+     * @type {String}
+     */
+    name: "Kiss User",
+
+    /** Command's Description
+     * @type {String}
+     */
+    description: "Give the User a kiss!",
+
+    /** Type of Context Command
+     * @type {ApplicationCommandType}
+     */
+    commandType: ApplicationCommandType.User,
+
+    /** Command's cooldown, in seconds (whole number integers!)
+     * @type {Number}
+     */
+    cooldown: 3,
+    
+
+    /** Get the Command's data in a format able to be registered with via Discord's API
+     * @returns {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody}
+     */
+    getRegisterData() {
+        /** @type {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody} */
+        const CommandData = {};
+
+        CommandData.name = this.name;
+        CommandData.description = "";
+        CommandData.type = this.commandType;
+        // Integration Types - 0 for GUILD_INSTALL, 1 for USER_INSTALL.
+        //  MUST include at least one. 
+        CommandData.integration_types = [ ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall ];
+        // Contexts - 0 for GUILD, 1 for BOT_DM (DMs with the App), 2 for PRIVATE_CHANNEL (DMs/GDMs that don't include the App).
+        //  MUST include at least one. PRIVATE_CHANNEL can only be used if integration_types includes USER_INSTALL
+        CommandData.contexts = [ InteractionContextType.Guild, InteractionContextType.PrivateChannel ];
+
+        return CommandData;
+    },
+
+    /** Runs the Command
+     * @param {import('discord-api-types/v10').APIUserApplicationCommandGuildInteraction|import('discord-api-types/v10').APIUserApplicationCommandDMInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     */
+    async executeCommand(interaction, interactionUser) {
+        // Grab data
+        const TargetUser = interaction.data.resolved.users[interaction.data.target_id];
+        const TargetMember = interaction.data.resolved.members != undefined ? interaction.data.resolved.members[interaction.data.target_id] : undefined;
+        
+        // Get highest-level display name for Target
+        const TargetDisplayName = TargetMember != undefined && TargetMember.nick != null ? TargetMember.nick
+            : TargetMember != undefined && TargetMember.nick == null && TargetUser.global_name != null ? TargetUser.global_name
+            : TargetMember == undefined && TargetUser.global_name != null ? TargetUser.global_name
+            : TargetUser.username;
+
+        // Do the same, but for User who triggered this Command
+        const SenderDisplayName = interaction.member != undefined && interaction.member.nick != null ? interaction.member.nick
+            : interaction.member != undefined && interaction.member.nick == null && interaction.member.user.global_name != null ? interaction.member.user.global_name
+            : interaction.member != undefined && interaction.member.nick == null && interaction.member.user.global_name == null ? interaction.member.user.username
+            : interaction.member == undefined && interaction.user.global_name != null ? interaction.user.global_name
+            : interaction.user.username;
+        const SenderId = interaction.member != undefined ? interaction.member.user.id : interaction.user.id;
+
+
+        // Assemble message
+        let displayMessage = "";
+
+        // Used on self
+        if ( interaction.data.target_id === SenderId ) {
+            displayMessage = localize(interaction.locale, 'ACTION_COMMAND_SELF_USER_KISS', SenderDisplayName);
+        }
+        // Used on this App
+        else if ( interaction.data.target_id === DISCORD_APP_USER_ID ) {
+            displayMessage = localize(interaction.locale, 'ACTION_COMMAND_TWILITE_KISS', SenderDisplayName);
+        }
+        // Used on Mee6, that yucky App that should be unverified :c
+        else if ( interaction.data.target_id === "159985870458322944" ) {
+            displayMessage = localize(interaction.locale, 'ACTION_COMMAND_MEE6_KISS', SenderDisplayName, `<@159985870458322944>`);
+        }
+        // Used on any other App
+        else if ( TargetUser.bot || TargetMember?.user?.bot ) {
+            displayMessage = localize(interaction.locale, 'ACTION_COMMAND_OTHER_APPS_KISS', SenderDisplayName, TargetDisplayName)
+        }
+        // Used on any non-App User
+        else {
+            displayMessage = localize(interaction.locale, 'ACTION_COMMAND_OTHER_USER_KISS', SenderDisplayName, TargetDisplayName);
+        }
+
+        // ACK message
+        return new JsonResponse({
+            type: InteractionResponseType.ChannelMessageWithSource,
+            data: {
+                content: displayMessage,
+                allowed_mentions: { parse: [], users: ['159985870458322944'] }
+            }
+        });
+    }
+}

--- a/Commands/SlashCommands/Actions/slap.js
+++ b/Commands/SlashCommands/Actions/slap.js
@@ -1,0 +1,142 @@
+import { ApplicationCommandType, InteractionContextType, ApplicationIntegrationType, MessageFlags, InteractionResponseType, ApplicationCommandOptionType } from 'discord-api-types/v10';
+import { JsonResponse } from '../../../Utility/utilityMethods.js';
+import { handleActionSlashCommand } from '../../../Modules/ActionModule.js';
+import { localize } from '../../../Utility/localizeResponses.js';
+
+
+export const SlashCommand = {
+    /** Command's Name, in fulllowercase (can include hyphens)
+     * @type {String}
+     */
+    name: "slap",
+
+    /** Command's Description
+     * @type {String}
+     */
+    description: "Slaps the selected target",
+
+    /** Command's Localised Descriptions
+     * @type {import('discord-api-types/v10').LocalizationMap}
+     */
+    localizedDescriptions: {
+        'en-GB': 'Slaps the selected target',
+        'en-US': 'Slaps the selected target'
+    },
+
+    /** Command's cooldown, in seconds (whole number integers!)
+     * @type {Number}
+     */
+    cooldown: 3,
+
+    /**
+     * Cooldowns for specific Subcommands
+     */
+    // Where "exampleName" is either the Subcommand's Name, or a combo of both Subcommand Group Name and Subcommand Name
+    //  For ease in handling cooldowns, this should also include the root Command name as a prefix
+    // In either "rootCommandName_subcommandName" or "rootCommandName_groupName_subcommandName" formats
+    subcommandCooldown: {
+        "exampleName": 3
+    },
+    
+
+    /** Get the Command's data in a format able to be registered with via Discord's API
+     * @returns {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody}
+     */
+    getRegisterData() {
+        /** @type {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody} */
+        const CommandData = {};
+
+        CommandData.name = this.name;
+        CommandData.description = this.description;
+        CommandData.description_localizations = this.localizedDescriptions;
+        CommandData.type = ApplicationCommandType.ChatInput;
+        // Integration Types - 0 for GUILD_INSTALL, 1 for USER_INSTALL.
+        //  MUST include at least one. 
+        CommandData.integration_types = [ ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall ];
+        // Contexts - 0 for GUILD, 1 for BOT_DM (DMs with the App), 2 for PRIVATE_CHANNEL (DMs/GDMs that don't include the App).
+        //  MUST include at least one. PRIVATE_CHANNEL can only be used if integration_types includes USER_INSTALL
+        CommandData.contexts = [ InteractionContextType.Guild, InteractionContextType.PrivateChannel ];
+        // Options
+        CommandData.options = [
+            {
+                type: ApplicationCommandOptionType.Mentionable,
+                name: "target",
+                description: "The target you want to slap",
+                description_localizations: {
+                    'en-GB': "The target you want to slap",
+                    'en-US': "The target you want to slap"
+                },
+                required: true
+            },
+            {
+                type: ApplicationCommandOptionType.Boolean,
+                name: "include-gif",
+                description: "Should a random GIF be displayed? (default: false)",
+                description_localizations: {
+                    'en-GB': "Should a random GIF be displayed? (default: false)",
+                    'en-US': "Should a random GIF be displayed? (default: false)"
+                },
+                required: false
+            },
+            {
+                type: ApplicationCommandOptionType.Boolean,
+                name: "block-return",
+                description: "Set to TRUE to prevent the \"Return Slap\" Button from being included in the response",
+                description_localizations: {
+                    'en-GB': "Set to TRUE to prevent the \"Return Slap\" Button from being included in the response",
+                    'en-US': "Set to TRUE to prevent the \"Return Slap\" Button from being included in the response"
+                },
+                required: false
+            },
+            {
+                type: ApplicationCommandOptionType.String,
+                name: "reason",
+                description: "An optional custom reason to be added onto the end of the displayed message",
+                description_localizations: {
+                    'en-GB': "An optional custom reason to be added onto the end of the displayed message",
+                    'en-US': "An optional custom reason to be added onto the end of the displayed message"
+                },
+                required: false,
+                max_length: 500
+            }
+        ];
+
+        return CommandData;
+    },
+
+    /** Handles given Autocomplete Interactions, should this Command use Autocomplete Options
+     * @param {import('discord-api-types/v10').APIApplicationCommandAutocompleteInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     */
+    async handleAutoComplete(interaction, interactionUser) {
+        return new JsonResponse({
+            type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+            data: {
+                choices: [ {name: "Not implemented yet!", value: "NOT_IMPLEMENTED"} ]
+            }
+        });
+    },
+
+    /** Runs the Command
+     * @param {import('discord-api-types/v10').APIChatInputApplicationCommandInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     * @param {String} usedCommandName 
+     */
+    async executeCommand(interaction, interactionUser, usedCommandName) {
+        try {
+            return await handleActionSlashCommand(interaction, interactionUser, usedCommandName);
+        }
+        catch (err) {
+            console.error(err);
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'SLASH_COMMAND_ERROR_GENERIC')
+                }
+            });
+        }
+
+        return;
+    }
+}

--- a/Locales/en-GB.cjs
+++ b/Locales/en-GB.cjs
@@ -75,6 +75,7 @@ module.exports = {
     ACTION_COMMAND_OTHER_USER_KISS: `**{{0}}** kissed **{{1}}**`,
     ACTION_COMMAND_OTHER_USER_YEET: `**{{0}}** yeeted **{{1}}**`,
     ACTION_COMMAND_OTHER_USER_COOKIE: `**{{0}}** gave a cookie to **{{1}}**`,
+    ACTION_COMMAND_OTHER_USER_SLAP: `**{{0}}** slapped **{{1}}**`,
 
     ACTION_COMMAND_SELF_USER_HEADPAT: `**{{0}}** gave themself a headpat`,
     ACTION_COMMAND_SELF_USER_HUG: `**{{0}}** gave themself a cuddle`,
@@ -83,6 +84,7 @@ module.exports = {
     ACTION_COMMAND_SELF_USER_KISS: `**{{0}}** attempted to kiss themself`,
     ACTION_COMMAND_SELF_USER_YEET: `**{{0}}** yeeted themselves out of a cannon`,
     ACTION_COMMAND_SELF_USER_COOKIE: `**{{0}}** snuck a cookie out of the cookie jar for themselves`,
+    ACTION_COMMAND_SELF_USER_SLAP: `**{{0}}** slapped themselves`,
 
     ACTION_COMMAND_ROLE_HEADPAT: `**{{0}}** gave everyone with **{{1}}** headpats`,
     ACTION_COMMAND_ROLE_HUG: `**{{0}}** gave everyone with **{{1}}** a group hug`,
@@ -91,6 +93,7 @@ module.exports = {
     ACTION_COMMAND_ROLE_KISS: `**{{0}}** kissed everyone with **{{1}}**`,
     ACTION_COMMAND_ROLE_YEET: `**{{0}}** collectively yeeted **{{1}}**`,
     ACTION_COMMAND_ROLE_COOKIE: `**{{0}}** gave **{{1}}** a cookie`,
+    ACTION_COMMAND_ROLE_SLAP: `**{{0}}** collectively slapped **{{1}}**`,
 
     ACTION_COMMAND_EVERYONE_HEADPAT: `**{{0}}** gave \`@everyone\` a headpat`,
     ACTION_COMMAND_EVERYONE_HUG: `**{{0}}** gave \`@everyone\` a group hug`,
@@ -99,6 +102,7 @@ module.exports = {
     ACTION_COMMAND_EVERYONE_KISS: `**{{0}}** gave \`@everyone\` a kiss`,
     ACTION_COMMAND_EVERYONE_YEET: `**{{0}}** yeeted \`@everyone\` with a catapult`,
     ACTION_COMMAND_EVERYONE_COOKIE: `**{{0}}** gave \`@everyone\` a cookie`,
+    ACTION_COMMAND_EVERYONE_SLAP: `**{{0}}** slapped \`@everyone\``,
 
     ACTION_COMMAND_OTHER_APPS_HEADPAT: `**{{0}}** gave **{{1}}** a virtual headpat`,
     ACTION_COMMAND_OTHER_APPS_HUG: `**{{0}}** virtually cuddled **{{1}}**`,
@@ -107,6 +111,7 @@ module.exports = {
     ACTION_COMMAND_OTHER_APPS_KISS: `**{{0}}** sent **{{1}}** a virtual kiss`,
     ACTION_COMMAND_OTHER_APPS_YEET: `**{{0}}** yeeted **{{1}}** out the internet`,
     ACTION_COMMAND_OTHER_APPS_COOKIE: `**{{0}}** gave **{{1}}** a virtual cookie`,
+    ACTION_COMMAND_OTHER_APPS_SLAP: `**{{0}}** slapped **{{1}}**'s physical servers`,
 
     ACTION_COMMAND_TWILITE_HEADPAT: `**{{0}}** gave me a headpat <3`,
     ACTION_COMMAND_TWILITE_HUG: `**{{0}}** cuddled me <3`,
@@ -115,6 +120,7 @@ module.exports = {
     ACTION_COMMAND_TWILITE_KISS: `**{{0}}** kissed...me? :flushed:`,
     ACTION_COMMAND_TWILITE_YEET: `I gave **{{0}}** flying lessons for trying to yeet me!`,
     ACTION_COMMAND_TWILITE_COOKIE: `**{{0}}** gave me a virtual cookie!`,
+    ACTION_COMMAND_TWILITE_SLAP: `**{{0}}** slapped me?! How dare you!`,
 
     ACTION_COMMAND_MEE6_HEADPAT: `***{{0}}** gave **{{1}}** a headpat...*`,
     ACTION_COMMAND_MEE6_HUG: `***{{0}}** hugged **{{1}}**...*`,
@@ -123,18 +129,21 @@ module.exports = {
     ACTION_COMMAND_MEE6_KISS: `OK, listen **{{0}}**, **{{1}}** doesn't deserve a kiss.`,
     ACTION_COMMAND_MEE6_YEET: `**{{0}}** absolutely YEETED **{{1}}**`,
     ACTION_COMMAND_MEE6_COOKIE: `**{{0}}** gave **{{1}}** a cookie from the Dark Side`,
+    ACTION_COMMAND_MEE6_SLAP: `**{{0}}** gave **{{1}}** a royal slapping`,
 
     ACTION_RETURN_BUTTON_LABEL_HEADPAT: `Return Headpat`,
     ACTION_RETURN_BUTTON_LABEL_HUG: `Return Hug`,
     ACTION_RETURN_BUTTON_LABEL_BONK: `Return Bonk`,
     ACTION_RETURN_BUTTON_LABEL_BOOP: `Return Boop`,
     ACTION_RETURN_BUTTON_LABEL_KISS: `Return Kiss`,
+    ACTION_RETURN_BUTTON_LABEL_SLAP: `Return Slap`,
 
     ACTION_RETURN_HEADPAT: `**{{0}}** gave **{{1}}** a headpat in return!`,
     ACTION_RETURN_HUG: `**{{0}}** cuddled **{{1}}** too!`,
     ACTION_RETURN_BONK: `**{{0}}** bonked **{{1}}** in retaliation!`,
     ACTION_RETURN_BOOP: `**{{0}}** revenge booped **{{1}}**!`,
     ACTION_RETURN_KISS: `**{{0}}** kissed **{{1}}** in return!`,
+    ACTION_RETURN_SLAP: `**{{0}}** slapped **{{1}}** in retaliation!`,
 
     ACTION_ERROR_RETURN_NOT_TARGETED_AT_SELF: `You cannot return an Action that wasn't aimed at you!`,
     ACTION_ERROR_CANNOT_RETURN_TO_SENDER: `You cannot return the Action you sent!`,

--- a/Locales/en-US.cjs
+++ b/Locales/en-US.cjs
@@ -75,6 +75,7 @@ module.exports = {
     ACTION_COMMAND_OTHER_USER_KISS: `**{{0}}** kissed **{{1}}**`,
     ACTION_COMMAND_OTHER_USER_YEET: `**{{0}}** yeeted **{{1}}**`,
     ACTION_COMMAND_OTHER_USER_COOKIE: `**{{0}}** gave a cookie to **{{1}}**`,
+    ACTION_COMMAND_OTHER_USER_SLAP: `**{{0}}** slapped **{{1}}**`,
 
     ACTION_COMMAND_SELF_USER_HEADPAT: `**{{0}}** gave themself a headpat`,
     ACTION_COMMAND_SELF_USER_HUG: `**{{0}}** gave themself a cuddle`,
@@ -83,6 +84,7 @@ module.exports = {
     ACTION_COMMAND_SELF_USER_KISS: `**{{0}}** attempted to kiss themself`,
     ACTION_COMMAND_SELF_USER_YEET: `**{{0}}** yeeted themselves out of a cannon`,
     ACTION_COMMAND_SELF_USER_COOKIE: `**{{0}}** snuck a cookie out of the cookie jar for themselves`,
+    ACTION_COMMAND_SELF_USER_SLAP: `**{{0}}** slapped themselves`,
 
     ACTION_COMMAND_ROLE_HEADPAT: `**{{0}}** gave everyone with **{{1}}** headpats`,
     ACTION_COMMAND_ROLE_HUG: `**{{0}}** gave everyone with **{{1}}** a group hug`,
@@ -91,6 +93,7 @@ module.exports = {
     ACTION_COMMAND_ROLE_KISS: `**{{0}}** kissed everyone with **{{1}}**`,
     ACTION_COMMAND_ROLE_YEET: `**{{0}}** collectively yeeted **{{1}}**`,
     ACTION_COMMAND_ROLE_COOKIE: `**{{0}}** gave **{{1}}** a cookie`,
+    ACTION_COMMAND_ROLE_SLAP: `**{{0}}** collectively slapped **{{1}}**`,
 
     ACTION_COMMAND_EVERYONE_HEADPAT: `**{{0}}** gave \`@everyone\` a headpat`,
     ACTION_COMMAND_EVERYONE_HUG: `**{{0}}** gave \`@everyone\` a group hug`,
@@ -99,6 +102,7 @@ module.exports = {
     ACTION_COMMAND_EVERYONE_KISS: `**{{0}}** gave \`@everyone\` a kiss`,
     ACTION_COMMAND_EVERYONE_YEET: `**{{0}}** yeeted \`@everyone\` with a catapult`,
     ACTION_COMMAND_EVERYONE_COOKIE: `**{{0}}** gave \`@everyone\` a cookie`,
+    ACTION_COMMAND_EVERYONE_SLAP: `**{{0}}** slapped \`@everyone\``,
 
     ACTION_COMMAND_OTHER_APPS_HEADPAT: `**{{0}}** gave **{{1}}** a virtual headpat`,
     ACTION_COMMAND_OTHER_APPS_HUG: `**{{0}}** virtually cuddled **{{1}}**`,
@@ -107,6 +111,7 @@ module.exports = {
     ACTION_COMMAND_OTHER_APPS_KISS: `**{{0}}** sent **{{1}}** a virtual kiss`,
     ACTION_COMMAND_OTHER_APPS_YEET: `**{{0}}** yeeted **{{1}}** out the internet`,
     ACTION_COMMAND_OTHER_APPS_COOKIE: `**{{0}}** gave **{{1}}** a virtual cookie`,
+    ACTION_COMMAND_OTHER_APPS_SLAP: `**{{0}}** slapped **{{1}}**'s physical servers`,
 
     ACTION_COMMAND_TWILITE_HEADPAT: `**{{0}}** gave me a headpat <3`,
     ACTION_COMMAND_TWILITE_HUG: `**{{0}}** cuddled me <3`,
@@ -115,6 +120,7 @@ module.exports = {
     ACTION_COMMAND_TWILITE_KISS: `**{{0}}** kissed...me? :flushed:`,
     ACTION_COMMAND_TWILITE_YEET: `I gave **{{0}}** flying lessons for trying to yeet me!`,
     ACTION_COMMAND_TWILITE_COOKIE: `**{{0}}** gave me a virtual cookie!`,
+    ACTION_COMMAND_TWILITE_SLAP: `**{{0}}** slapped me?! How dare you!`,
 
     ACTION_COMMAND_MEE6_HEADPAT: `***{{0}}** gave **{{1}}** a headpat...*`,
     ACTION_COMMAND_MEE6_HUG: `***{{0}}** hugged **{{1}}**...*`,
@@ -123,18 +129,21 @@ module.exports = {
     ACTION_COMMAND_MEE6_KISS: `OK, listen **{{0}}**, **{{1}}** doesn't deserve a kiss.`,
     ACTION_COMMAND_MEE6_YEET: `**{{0}}** absolutely YEETED **{{1}}**`,
     ACTION_COMMAND_MEE6_COOKIE: `**{{0}}** gave **{{1}}** a cookie from the Dark Side`,
+    ACTION_COMMAND_MEE6_SLAP: `**{{0}}** gave **{{1}}** a royal slapping`,
 
     ACTION_RETURN_BUTTON_LABEL_HEADPAT: `Return Headpat`,
     ACTION_RETURN_BUTTON_LABEL_HUG: `Return Hug`,
     ACTION_RETURN_BUTTON_LABEL_BONK: `Return Bonk`,
     ACTION_RETURN_BUTTON_LABEL_BOOP: `Return Boop`,
     ACTION_RETURN_BUTTON_LABEL_KISS: `Return Kiss`,
+    ACTION_RETURN_BUTTON_LABEL_SLAP: `Return Slap`,
 
     ACTION_RETURN_HEADPAT: `**{{0}}** gave **{{1}}** a headpat in return!`,
     ACTION_RETURN_HUG: `**{{0}}** cuddled **{{1}}** too!`,
     ACTION_RETURN_BONK: `**{{0}}** bonked **{{1}}** in retaliation!`,
     ACTION_RETURN_BOOP: `**{{0}}** revenge booped **{{1}}**!`,
     ACTION_RETURN_KISS: `**{{0}}** kissed **{{1}}** in return!`,
+    ACTION_RETURN_SLAP: `**{{0}}** slapped **{{1}}** in retaliation!`,
 
     ACTION_ERROR_RETURN_NOT_TARGETED_AT_SELF: `You cannot return an Action that wasn't aimed at you!`,
     ACTION_ERROR_CANNOT_RETURN_TO_SENDER: `You cannot return the Action you sent!`,

--- a/Utility/interactions.js
+++ b/Utility/interactions.js
@@ -7,6 +7,7 @@ export const SlashCommands = {
     'hug': () => import('../Commands/SlashCommands/Actions/hug.js'),
     'kiss': () => import('../Commands/SlashCommands/Actions/kiss.js'),
     'yeet': () => import('../Commands/SlashCommands/Actions/yeet.js'),
+    'slap': () => import('../Commands/SlashCommands/Actions/slap.js'),
 
     // ***** FOR ROLE MENUS
     'rolemenu': () => import('../Commands/SlashCommands/RoleMenus/rolemenu.js'),

--- a/Utility/interactions.js
+++ b/Utility/interactions.js
@@ -23,6 +23,7 @@ export const ContextCommands = {
     'Bonk User': () => import('../Commands/ContextCommands/Actions/Bonk_User.js'),
     'Boop User': () => import('../Commands/ContextCommands/Actions/Boop_User.js'),
     'Headpat User': () => import('../Commands/ContextCommands/Actions/Headpat_User.js'),
+    'Kiss User': () => import('../Commands/ContextCommands/Actions/Kiss_User.js'),
 
     // ***** FOR ROLE MENUS
     'Edit Role Menu': () => import('../Commands/ContextCommands/RoleMenus/Edit_Role_Menu.js'),


### PR DESCRIPTION
Adds two new Action Commands, as requested by a couple friends.

These new Action CMDs are:
- `/slap` Slash Command
- "`Kiss User`" User Context Command

> [!NOTE]
> A little fun fact - `/slap` did actually used to be a part of this App years ago (back when it was called "MooBot"), but was removed. I don't recall why. You can find the changelog that previously removed `/slap` [here on the old Repo](https://github.com/TwilightZebby/MooBot/releases/tag/6.0.0).

closes #5 

---

This PR will be https://github.com/TwilightZebby/TwiLite/labels/blocked from merging until #4 is merged - due to `/slap` making use of the revived Return Action Button that #4 re-added.