### PR TITLE
Support `APPLICATION_DEAUTHORIZED` Webhook Event

### DIFF
--- a/Handlers/WebhookEvents/applicationDeauthorized.js
+++ b/Handlers/WebhookEvents/applicationDeauthorized.js
@@ -6,20 +6,17 @@ import { DISCORD_APP_USER_ID, DISCORD_TOKEN, LOG_WEBHOOK_ID, LOG_WEBHOOK_TOKEN }
 //  Exports
 
 /**
- * Handles APPLICATION_AUTHORIZED Webhook Events
+ * Handles APPLICATION_DEAUTHORIZED Webhook Events
  * @param {import('discord-api-types/v10').APIWebhookEvent} webhookEvent 
  * 
  * @returns {JsonResponse}
  */
-export async function handleAppAuthorized(webhookEvent) {
+export async function handleAppDeauthorized(webhookEvent) {
+    // For some reason, Discord decided NOT to include GUILD-based deauth's, and only USER-based deauth's, for this event. Why? I have no idea. :c
+    
     // Format into a message
-    /** @type {'Server'|'User'} */
-    let appType = webhookEvent.event.data.integration_type === 0 ? `Server` : `User`;
     /** @type {import('discord-api-types/v10').APIUser} */
-    let authedUser = webhookEvent.event.data.user;
-    let authedScopes = webhookEvent.event.data.scopes;
-    /** @type {import('discord-api-types/v10').APIGuild | undefined} */
-    let authedGuild = webhookEvent.event.data.guild;
+    let DeauthedUser = webhookEvent.event.data.user;
 
     // Fetch App's install count
     let fetchedApp = await fetch(`https://discord.com/api/v10/applications/${DISCORD_APP_USER_ID}`, {
@@ -29,11 +26,10 @@ export async function handleAppAuthorized(webhookEvent) {
         }
     });
     let appData = await fetchedApp.json();
-    let guildInstallCount = appData["approximate_guild_count"];
     let userInstallCount = appData["approximate_user_install_count"];
     let userAuthCount = appData["approximate_user_authorization_count"];
 
-    let newAuthMessage = `## :chart_with_upwards_trend: New Authorisation\nAdded as a **${appType} App** by **${authedUser.global_name != null ? authedUser.global_name : authedUser.username}** ( <@${authedUser.id}> ) ${appType === 'Server' ? `to the **${authedGuild?.name}** Server (ID: ${authedGuild?.id})` : ''}.\nScopes authorised for: ${authedScopes.join(' && ')}\nNew total Guild Install Count: ${guildInstallCount}\nNew total User Install Count: ${userInstallCount}\nNew total User Authorisation Count: ${userAuthCount}\n-# User Installs are with \`application.commands\` Scope. User Auths are via OAuth2.`;
+    let newAuthMessage = `## :chart_with_downwards_trend: Deauthorisation\nRemoved as a **User App** by **${DeauthedUser.global_name != null ? DeauthedUser.global_name : DeauthedUser.username}** ( <@${DeauthedUser.id}> ).\nNew total User Install Count: ${userInstallCount}\nNew total User Authorisation Count: ${userAuthCount}\n-# User Installs are with \`application.commands\` Scope. User Auths are via OAuth2.`;
 
     // Send to Logger Webhook
     await fetch(`https://discord.com/api/v10/webhooks/${LOG_WEBHOOK_ID}/${LOG_WEBHOOK_TOKEN}`, {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ import { handleSelect } from './Handlers/Interactions/selectHandler.js';
 import { handleAutocomplete } from './Handlers/Interactions/autocompleteHandler.js';
 import { handleModal } from './Handlers/Interactions/modalHandler.js';
 import { handleAppAuthorized } from './Handlers/WebhookEvents/applicationAuthorized.js';
+import { handleAppDeauthorized } from './Handlers/WebhookEvents/applicationDeauthorized.js';
 import { DISCORD_APP_PUBLIC_KEY, DISCORD_APP_USER_ID } from './config.js';
 import { JsonResponse } from './Utility/utilityMethods.js';
 
@@ -111,6 +112,10 @@ router.post('/webhook', async (request, env, ctx) => {
     // APPLICATION_AUTHORIZED Event
     if ( WebhookEvent.event.type === ApplicationWebhookEventType.ApplicationAuthorized ) {
         return await handleAppAuthorized(WebhookEvent);
+    }
+    // APPLICATION_DEAUTHORIZED Event
+    else if ( WebhookEvent.event.type === ApplicationWebhookEventType.ApplicationDeauthorized ) {
+        return await handleAppDeauthorized(WebhookEvent);
     }
     // Just in case
     else {


### PR DESCRIPTION
Adds support for the new `APPLICATION_DEAUTHORIZED` Webhook Event.

Also adds support for the new `approximate_user_authorization_count` Application field, which differs from the already existing `approximate_user_install_count` field.