### PR TITLE
Update Role Menu Previews to Components v2

### DIFF
--- a/Commands/SlashCommands/RoleMenus/rolemenu.js
+++ b/Commands/SlashCommands/RoleMenus/rolemenu.js
@@ -1,4 +1,4 @@
-import { ApplicationCommandType, InteractionContextType, ApplicationIntegrationType, MessageFlags, InteractionResponseType, PermissionFlagsBits, ApplicationCommandOptionType, ChannelType } from 'discord-api-types/v10';
+import { ApplicationCommandType, InteractionContextType, ApplicationIntegrationType, MessageFlags, InteractionResponseType, PermissionFlagsBits, ApplicationCommandOptionType, ChannelType, ComponentType, SeparatorSpacingSize } from 'discord-api-types/v10';
 import { ActionRowBuilder, EmbedBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder } from '@discordjs/builders';
 import { JsonResponse } from '../../../Utility/utilityMethods.js';
 import { localize } from '../../../Utility/localizeResponses.js';
@@ -164,37 +164,57 @@ export const SlashCommand = {
             
 
             // Create localized components
-            const EmptyEmbed = new EmbedBuilder().setDescription(localize(interaction.locale, 'ROLE_MENU_PREVIEW_EMPTY'));
-            
-            const SelectMenu = new ActionRowBuilder().addComponents([
-                new StringSelectMenuBuilder().setCustomId(`create-role-menu`).setMinValues(1).setMaxValues(1).setPlaceholder(localize(interaction.locale, 'ROLE_MENU_SELECT_AN_ACTION')).setOptions([
-                    new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_SET_MENU_TYPE')).setValue("set-type").setDescription(localize(interaction.locale, 'ROLE_MENU_SET_MENU_TYPE_DESCRIPTION')).setEmoji({ name: `🔧` }),
-                    new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_CONFIGURE_EMBED')).setValue("configure-embed").setDescription(localize(interaction.locale, 'ROLE_MENU_CONFIGURE_EMBED_DESCRIPTION')).setEmoji({ name: EMOJI_ICON_OLD_RICH_PRESENCE.name, id: EMOJI_ICON_OLD_RICH_PRESENCE.id }),
-                    new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_ADD_ROLE')).setValue("add-role").setDescription(localize(interaction.locale, 'ROLE_MENU_ADD_ROLE_DESCRIPTION')).setEmoji({ name: EMOJI_ROLE_ADD.name, id: EMOJI_ROLE_ADD.id }),
-                    new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_REMOVE_ROLE')).setValue("remove-role").setDescription(localize(interaction.locale, 'ROLE_MENU_REMOVE_ROLE_DESCRIPTION')).setEmoji({ name: EMOJI_ROLE_REMOVE.name, id: EMOJI_ROLE_REMOVE.id }),
-                    new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_ADD_REQUIREMENT')).setValue("add-requirement").setDescription(localize(interaction.locale, 'ROLE_MENU_ADD_REQUIREMENT_DESCRIPTION')).setEmoji({ name: EMOJI_REQUIREMENT_ADD.name, id: EMOJI_REQUIREMENT_ADD.id }),
-                    new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_REMOVE_REQUIREMENT')).setValue("remove-requirement").setDescription(localize(interaction.locale, 'ROLE_MENU_REMOVE_REQUIREMENT_DESCRIPTION')).setEmoji({ name: EMOJI_REQUIREMENT_REMOVE.name, id: EMOJI_REQUIREMENT_REMOVE.id }),
-                    new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_SAVE_AND_POST')).setValue("save").setDescription(localize(interaction.locale, 'ROLE_MENU_SAVE_AND_POST_DESCRIPTION')).setEmoji({ name: EMOJI_ICON_ROCKET.name, id: EMOJI_ICON_ROCKET.id }),
-                    new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_CANCEL_CREATION')).setValue("cancel").setDescription(localize(interaction.locale, 'ROLE_MENU_CANCEL_CREATION_DESCRIPTION')).setEmoji({ name: `❌`})
-                ])
-            ]);
-            
-            // JSONify for ACKing
-            let embedJson = EmptyEmbed.toJSON();
-            let selectJson = SelectMenu.toJSON();
+            /** @type {import('discord-api-types/v10').APIMessageTopLevelComponent[]} */
+            let menuPreviewComponents = [
+                {
+                    "id": 1,
+                    "type": ComponentType.TextDisplay,
+                    "content": localize(interaction.guild_locale, 'ROLE_MENU_CREATE_INTRUCTIONS', timestampFor15Minutes)
+                },
+                {
+                    "id": 2,
+                    "type": ComponentType.Separator,
+                    "divider": false,
+                    "spacing": SeparatorSpacingSize.Small
+                },
+                {
+                    "id": 3,
+                    "type": ComponentType.Container,
+                    "accent_color": null,
+                    "spoiler": false,
+                    "components": [
+                        {
+                            "id": 4,
+                            "type": ComponentType.TextDisplay,
+                            "content": localize(interaction.guild_locale, 'ROLE_MENU_PREVIEW_EMPTY')
+                        }
+                    ]
+                },
+                {
+                    "id": 20,
+                    "type": ComponentType.ActionRow,
+                    "components": [
+                        new StringSelectMenuBuilder().setId(21).setCustomId(`create-role-menu`).setMinValues(1).setMaxValues(1).setPlaceholder(localize(interaction.locale, 'ROLE_MENU_SELECT_AN_ACTION')).setOptions([
+                            new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_SET_MENU_TYPE')).setValue("set-type").setDescription(localize(interaction.locale, 'ROLE_MENU_SET_MENU_TYPE_DESCRIPTION')).setEmoji({ name: `🔧` }),
+                            new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_CONFIGURE_EMBED')).setValue("configure-embed").setDescription(localize(interaction.locale, 'ROLE_MENU_CONFIGURE_EMBED_DESCRIPTION')).setEmoji({ name: EMOJI_ICON_OLD_RICH_PRESENCE.name, id: EMOJI_ICON_OLD_RICH_PRESENCE.id }),
+                            new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_ADD_ROLE')).setValue("add-role").setDescription(localize(interaction.locale, 'ROLE_MENU_ADD_ROLE_DESCRIPTION')).setEmoji({ name: EMOJI_ROLE_ADD.name, id: EMOJI_ROLE_ADD.id }),
+                            new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_REMOVE_ROLE')).setValue("remove-role").setDescription(localize(interaction.locale, 'ROLE_MENU_REMOVE_ROLE_DESCRIPTION')).setEmoji({ name: EMOJI_ROLE_REMOVE.name, id: EMOJI_ROLE_REMOVE.id }),
+                            new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_ADD_REQUIREMENT')).setValue("add-requirement").setDescription(localize(interaction.locale, 'ROLE_MENU_ADD_REQUIREMENT_DESCRIPTION')).setEmoji({ name: EMOJI_REQUIREMENT_ADD.name, id: EMOJI_REQUIREMENT_ADD.id }),
+                            new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_REMOVE_REQUIREMENT')).setValue("remove-requirement").setDescription(localize(interaction.locale, 'ROLE_MENU_REMOVE_REQUIREMENT_DESCRIPTION')).setEmoji({ name: EMOJI_REQUIREMENT_REMOVE.name, id: EMOJI_REQUIREMENT_REMOVE.id }),
+                            new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_SAVE_AND_POST')).setValue("save").setDescription(localize(interaction.locale, 'ROLE_MENU_SAVE_AND_POST_DESCRIPTION')).setEmoji({ name: EMOJI_ICON_ROCKET.name, id: EMOJI_ICON_ROCKET.id }),
+                            new StringSelectMenuOptionBuilder().setLabel(localize(interaction.locale, 'ROLE_MENU_CANCEL_CREATION')).setValue("cancel").setDescription(localize(interaction.locale, 'ROLE_MENU_CANCEL_CREATION_DESCRIPTION')).setEmoji({ name: `❌`})
+                        ]).toJSON()
+                    ]
+                }
+            ];
 
-            // Cache Interaction so we can refer back to the original response :)
-            const UserId = interaction.member.user.id;
-            UtilityCollections.RoleMenuManagement.set(UserId, { interactionId: interaction.id, interactionToken: interaction.token, selectMenu: SelectMenu, menuEmbed: new EmbedBuilder(), menuButtons: [], roleRequirements: [], mainInstructions: localize(interaction.locale, 'ROLE_MENU_CREATE_INTRUCTIONS', timestampFor15Minutes) });
             
             // ACK
             return new JsonResponse({
                 type: InteractionResponseType.ChannelMessageWithSource,
                 data: {
-                    flags: MessageFlags.Ephemeral,
-                    content: localize(interaction.locale, 'ROLE_MENU_CREATE_INTRUCTIONS', timestampFor15Minutes),
-                    components: [selectJson],
-                    embeds: [embedJson]
+                    flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
+                    components: menuPreviewComponents,
                 }
             });
             

--- a/Interactions/Selects/RoleMenus/create-role-menu.js
+++ b/Interactions/Selects/RoleMenus/create-role-menu.js
@@ -207,16 +207,12 @@ export const Select = {
             // Cancels creation of Role menu
             case "cancel":
             default:
-                // Purge cache, just in case
-                UtilityCollections.RoleMenuManagement.delete(UserId);
                 // ACK
                 return new JsonResponse({
                     type: InteractionResponseType.UpdateMessage,
                     data: {
-                        flags: MessageFlags.Ephemeral,
-                        components: [],
-                        embeds: [],
-                        content: localize(interaction.locale, 'ROLE_MENU_CREATION_CANCELLED')
+                        flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
+                        components: [{ "id": 1, "type": ComponentType.TextDisplay, "content": localize(interaction.locale, 'ROLE_MENU_CREATION_CANCELLED') }],
                     }
                 });
         }


### PR DESCRIPTION
While the actual Role Menus, when posted in Channels for Server Members to use, have already been updated to use Components v2 - the preview of Role Menus *(shown during creation/configuration)* haven't.

This PR updates that preview to use Components v2. Thus, being a more accurate preview to what actually gets posted upon saving the Role Menu.

> [!IMPORTANT]
> This PR will be on hold ( https://github.com/TwilightZebby/TwiLite/labels/blocked ) until there's some way of doing this without needing a local cache to temp-store Role Menu data during creation/configuration.[^1]

[^1]: Currently, TwiLite uses a local cache to temp-store Role Menu data, including the data of the first Interaction Response, in order to get/edit said Interaction Response with the updated previews. In order to do this fully stateless, without the need of local caches or databases, I would need to be able to fetch/edit the first Interaction Response using only data that Discord's API returns. Which is not possible right now. This is a GREAT use-case for Discord's API & Apps Team to update Modals to support Selects & Emoji-inputs in them!