### PR TITLE
Action Commands: Tweak "Return Action" Button handling & add new Action Commands

### DIFF
--- a/Assets/ActionGifLinks.js
+++ b/Assets/ActionGifLinks.js
@@ -120,5 +120,39 @@ export const ActionGifs = {
         "https://twilite.is-from.space/r/action-bite-0007.gif",
         "https://twilite.is-from.space/r/action-bite-0008.gif",
         "https://twilite.is-from.space/r/action-bite-0009.gif"
-    ]
+    ],
+
+    "lick": [
+        "https://twilite.is-from.space/r/action-lick-0001.gif",
+        "https://twilite.is-from.space/r/action-lick-0002.gif",
+        "https://twilite.is-from.space/r/action-lick-0003.gif",
+        "https://twilite.is-from.space/r/action-lick-0004.gif",
+        "https://twilite.is-from.space/r/action-lick-0005.gif",
+        "https://twilite.is-from.space/r/action-lick-0006.gif",
+        "https://twilite.is-from.space/r/action-lick-0007.gif",
+        "https://twilite.is-from.space/r/action-lick-0008.gif",
+        "https://twilite.is-from.space/r/action-lick-0009.gif"
+    ],
+
+    "glare": [
+        "https://twilite.is-from.space/r/action-glare-0001.gif",
+        "https://twilite.is-from.space/r/action-glare-0002.gif",
+        "https://twilite.is-from.space/r/action-glare-0003.gif",
+        "https://twilite.is-from.space/r/action-glare-0004.gif",
+        "https://twilite.is-from.space/r/action-glare-0005.gif",
+        "https://twilite.is-from.space/r/action-glare-0006.gif",
+        "https://twilite.is-from.space/r/action-glare-0007.gif",
+        "https://twilite.is-from.space/r/action-glare-0008.gif"
+    ],
+
+    "explode": [
+        "https://twilite.is-from.space/r/action-explode-0001.gif",
+        "https://twilite.is-from.space/r/action-explode-0002.gif",
+        "https://twilite.is-from.space/r/action-explode-0003.gif",
+        "https://twilite.is-from.space/r/action-explode-0004.gif",
+        "https://twilite.is-from.space/r/action-explode-0005.gif",
+        "https://twilite.is-from.space/r/action-explode-0006.gif",
+        "https://twilite.is-from.space/r/action-explode-0007.gif",
+        "https://twilite.is-from.space/r/action-explode-0008.gif"
+    ],
 };

--- a/Commands/SlashCommands/Actions/bonk.js
+++ b/Commands/SlashCommands/Actions/bonk.js
@@ -78,7 +78,7 @@ export const SlashCommand = {
                 },
                 required: false
             },
-            {
+            /* {
                 type: ApplicationCommandOptionType.Boolean,
                 name: "block-return",
                 description: "Set to TRUE to prevent the \"Return Bonk\" Button from being included in the response",
@@ -87,7 +87,7 @@ export const SlashCommand = {
                     'en-US': "Set to TRUE to prevent the \"Return Bonk\" Button from being included in the response"
                 },
                 required: false
-            },
+            }, */
             {
                 type: ApplicationCommandOptionType.String,
                 name: "reason",

--- a/Commands/SlashCommands/Actions/boop.js
+++ b/Commands/SlashCommands/Actions/boop.js
@@ -78,7 +78,7 @@ export const SlashCommand = {
                 },
                 required: false
             },
-            {
+            /* {
                 type: ApplicationCommandOptionType.Boolean,
                 name: "block-return",
                 description: "Set to TRUE to prevent the \"Return Boop\" Button from being included in the response",
@@ -87,7 +87,7 @@ export const SlashCommand = {
                     'en-US': "Set to TRUE to prevent the \"Return Boop\" Button from being included in the response"
                 },
                 required: false
-            },
+            }, */
             {
                 type: ApplicationCommandOptionType.String,
                 name: "reason",

--- a/Commands/SlashCommands/Actions/explode.js
+++ b/Commands/SlashCommands/Actions/explode.js
@@ -1,0 +1,132 @@
+import { ApplicationCommandType, InteractionContextType, ApplicationIntegrationType, MessageFlags, InteractionResponseType, ApplicationCommandOptionType } from 'discord-api-types/v10';
+import { JsonResponse } from '../../../Utility/utilityMethods.js';
+import { handleActionSlashCommand } from '../../../Modules/ActionModule.js';
+import { localize } from '../../../Utility/localizeResponses.js';
+
+
+export const SlashCommand = {
+    /** Command's Name, in fulllowercase (can include hyphens)
+     * @type {String}
+     */
+    name: "explode",
+
+    /** Command's Description
+     * @type {String}
+     */
+    description: "Attempt to explode someone with your mind",
+
+    /** Command's Localised Descriptions
+     * @type {import('discord-api-types/v10').LocalizationMap}
+     */
+    localizedDescriptions: {
+        'en-GB': 'Attempt to explode someone with your mind',
+        'en-US': 'Attempt to explode someone with your mind'
+    },
+
+    /** Command's cooldown, in seconds (whole number integers!)
+     * @type {Number}
+     */
+    cooldown: 3,
+
+    /**
+     * Cooldowns for specific Subcommands
+     */
+    // Where "exampleName" is either the Subcommand's Name, or a combo of both Subcommand Group Name and Subcommand Name
+    //  For ease in handling cooldowns, this should also include the root Command name as a prefix
+    // In either "rootCommandName_subcommandName" or "rootCommandName_groupName_subcommandName" formats
+    subcommandCooldown: {
+        "exampleName": 3
+    },
+    
+
+    /** Get the Command's data in a format able to be registered with via Discord's API
+     * @returns {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody}
+     */
+    getRegisterData() {
+        /** @type {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody} */
+        const CommandData = {};
+
+        CommandData.name = this.name;
+        CommandData.description = this.description;
+        CommandData.description_localizations = this.localizedDescriptions;
+        CommandData.type = ApplicationCommandType.ChatInput;
+        // Integration Types - 0 for GUILD_INSTALL, 1 for USER_INSTALL.
+        //  MUST include at least one. 
+        CommandData.integration_types = [ ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall ];
+        // Contexts - 0 for GUILD, 1 for BOT_DM (DMs with the App), 2 for PRIVATE_CHANNEL (DMs/GDMs that don't include the App).
+        //  MUST include at least one. PRIVATE_CHANNEL can only be used if integration_types includes USER_INSTALL
+        CommandData.contexts = [ InteractionContextType.Guild, InteractionContextType.PrivateChannel ];
+        // Options
+        CommandData.options = [
+            {
+                type: ApplicationCommandOptionType.Mentionable,
+                name: "target",
+                description: "The target you want to explode",
+                description_localizations: {
+                    'en-GB': "The target you want to explode",
+                    'en-US': "The target you want to explode"
+                },
+                required: true
+            },
+            {
+                type: ApplicationCommandOptionType.Boolean,
+                name: "include-gif",
+                description: "Should a random GIF be displayed? (default: false)",
+                description_localizations: {
+                    'en-GB': "Should a random GIF be displayed? (default: false)",
+                    'en-US': "Should a random GIF be displayed? (default: false)"
+                },
+                required: false
+            },
+            {
+                type: ApplicationCommandOptionType.String,
+                name: "reason",
+                description: "An optional custom reason to be added onto the end of the displayed message",
+                description_localizations: {
+                    'en-GB': "An optional custom reason to be added onto the end of the displayed message",
+                    'en-US': "An optional custom reason to be added onto the end of the displayed message"
+                },
+                required: false,
+                max_length: 500
+            }
+        ];
+
+        return CommandData;
+    },
+
+    /** Handles given Autocomplete Interactions, should this Command use Autocomplete Options
+     * @param {import('discord-api-types/v10').APIApplicationCommandAutocompleteInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     */
+    async handleAutoComplete(interaction, interactionUser) {
+        return new JsonResponse({
+            type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+            data: {
+                choices: [ {name: "Not implemented yet!", value: "NOT_IMPLEMENTED"} ]
+            }
+        });
+    },
+
+    /** Runs the Command
+     * @param {import('discord-api-types/v10').APIChatInputApplicationCommandInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     * @param {String} usedCommandName 
+     */
+    async executeCommand(interaction, interactionUser, usedCommandName) {
+        try {
+            return await handleActionSlashCommand(interaction, interactionUser, usedCommandName);
+        }
+        catch (err) {
+            console.error(err);
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'SLASH_COMMAND_ERROR_GENERIC')
+                }
+            });
+        }
+
+        return;
+    }
+}

--- a/Commands/SlashCommands/Actions/glare.js
+++ b/Commands/SlashCommands/Actions/glare.js
@@ -1,0 +1,132 @@
+import { ApplicationCommandType, InteractionContextType, ApplicationIntegrationType, MessageFlags, InteractionResponseType, ApplicationCommandOptionType } from 'discord-api-types/v10';
+import { JsonResponse } from '../../../Utility/utilityMethods.js';
+import { handleActionSlashCommand } from '../../../Modules/ActionModule.js';
+import { localize } from '../../../Utility/localizeResponses.js';
+
+
+export const SlashCommand = {
+    /** Command's Name, in fulllowercase (can include hyphens)
+     * @type {String}
+     */
+    name: "glare",
+
+    /** Command's Description
+     * @type {String}
+     */
+    description: "Glare at someone",
+
+    /** Command's Localised Descriptions
+     * @type {import('discord-api-types/v10').LocalizationMap}
+     */
+    localizedDescriptions: {
+        'en-GB': 'Glare at someone',
+        'en-US': 'Glare at someone'
+    },
+
+    /** Command's cooldown, in seconds (whole number integers!)
+     * @type {Number}
+     */
+    cooldown: 3,
+
+    /**
+     * Cooldowns for specific Subcommands
+     */
+    // Where "exampleName" is either the Subcommand's Name, or a combo of both Subcommand Group Name and Subcommand Name
+    //  For ease in handling cooldowns, this should also include the root Command name as a prefix
+    // In either "rootCommandName_subcommandName" or "rootCommandName_groupName_subcommandName" formats
+    subcommandCooldown: {
+        "exampleName": 3
+    },
+    
+
+    /** Get the Command's data in a format able to be registered with via Discord's API
+     * @returns {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody}
+     */
+    getRegisterData() {
+        /** @type {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody} */
+        const CommandData = {};
+
+        CommandData.name = this.name;
+        CommandData.description = this.description;
+        CommandData.description_localizations = this.localizedDescriptions;
+        CommandData.type = ApplicationCommandType.ChatInput;
+        // Integration Types - 0 for GUILD_INSTALL, 1 for USER_INSTALL.
+        //  MUST include at least one. 
+        CommandData.integration_types = [ ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall ];
+        // Contexts - 0 for GUILD, 1 for BOT_DM (DMs with the App), 2 for PRIVATE_CHANNEL (DMs/GDMs that don't include the App).
+        //  MUST include at least one. PRIVATE_CHANNEL can only be used if integration_types includes USER_INSTALL
+        CommandData.contexts = [ InteractionContextType.Guild, InteractionContextType.PrivateChannel ];
+        // Options
+        CommandData.options = [
+            {
+                type: ApplicationCommandOptionType.Mentionable,
+                name: "target",
+                description: "The target you want to glare at",
+                description_localizations: {
+                    'en-GB': "The target you want to glare at",
+                    'en-US': "The target you want to glare at"
+                },
+                required: true
+            },
+            {
+                type: ApplicationCommandOptionType.Boolean,
+                name: "include-gif",
+                description: "Should a random GIF be displayed? (default: false)",
+                description_localizations: {
+                    'en-GB': "Should a random GIF be displayed? (default: false)",
+                    'en-US': "Should a random GIF be displayed? (default: false)"
+                },
+                required: false
+            },
+            {
+                type: ApplicationCommandOptionType.String,
+                name: "reason",
+                description: "An optional custom reason to be added onto the end of the displayed message",
+                description_localizations: {
+                    'en-GB': "An optional custom reason to be added onto the end of the displayed message",
+                    'en-US': "An optional custom reason to be added onto the end of the displayed message"
+                },
+                required: false,
+                max_length: 500
+            }
+        ];
+
+        return CommandData;
+    },
+
+    /** Handles given Autocomplete Interactions, should this Command use Autocomplete Options
+     * @param {import('discord-api-types/v10').APIApplicationCommandAutocompleteInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     */
+    async handleAutoComplete(interaction, interactionUser) {
+        return new JsonResponse({
+            type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+            data: {
+                choices: [ {name: "Not implemented yet!", value: "NOT_IMPLEMENTED"} ]
+            }
+        });
+    },
+
+    /** Runs the Command
+     * @param {import('discord-api-types/v10').APIChatInputApplicationCommandInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     * @param {String} usedCommandName 
+     */
+    async executeCommand(interaction, interactionUser, usedCommandName) {
+        try {
+            return await handleActionSlashCommand(interaction, interactionUser, usedCommandName);
+        }
+        catch (err) {
+            console.error(err);
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'SLASH_COMMAND_ERROR_GENERIC')
+                }
+            });
+        }
+
+        return;
+    }
+}

--- a/Commands/SlashCommands/Actions/headpat.js
+++ b/Commands/SlashCommands/Actions/headpat.js
@@ -78,7 +78,7 @@ export const SlashCommand = {
                 },
                 required: false
             },
-            {
+            /* {
                 type: ApplicationCommandOptionType.Boolean,
                 name: "block-return",
                 description: "Set to TRUE to prevent the \"Return Headpat\" Button from being included in the response",
@@ -87,7 +87,7 @@ export const SlashCommand = {
                     'en-US': "Set to TRUE to prevent the \"Return Headpat\" Button from being included in the response"
                 },
                 required: false
-            },
+            }, */
             {
                 type: ApplicationCommandOptionType.String,
                 name: "reason",

--- a/Commands/SlashCommands/Actions/hug.js
+++ b/Commands/SlashCommands/Actions/hug.js
@@ -78,7 +78,7 @@ export const SlashCommand = {
                 },
                 required: false
             },
-            {
+            /* {
                 type: ApplicationCommandOptionType.Boolean,
                 name: "block-return",
                 description: "Set to TRUE to prevent the \"Return Hug\" Button from being included in the response",
@@ -87,7 +87,7 @@ export const SlashCommand = {
                     'en-US': "Set to TRUE to prevent the \"Return Hug\" Button from being included in the response"
                 },
                 required: false
-            },
+            }, */
             {
                 type: ApplicationCommandOptionType.String,
                 name: "reason",

--- a/Commands/SlashCommands/Actions/jail.js
+++ b/Commands/SlashCommands/Actions/jail.js
@@ -79,7 +79,7 @@ export const SlashCommand = {
                 required: false,
                 max_length: 500
             },
-            {
+            /* {
                 type: ApplicationCommandOptionType.Boolean,
                 name: "include-minigame",
                 description: "Set to true to include the \"break free from jail\" buttons",
@@ -88,7 +88,7 @@ export const SlashCommand = {
                     'en-US': "Set to true to include the \"break free from jail\" buttons"
                 },
                 required: false
-            },
+            }, */
         ];
 
         return CommandData;
@@ -116,7 +116,7 @@ export const SlashCommand = {
         // Grab Inputs
         const InputTarget = interaction.data.options.find(option => option.name === "target");
         const InputReason = interaction.data.options.find(option => option.name === "reason");
-        const InputIncludeMinigame = interaction.data.options.find(option => option.name === "include-minigame");
+        const InputIncludeMinigame = interaction.data.options.find(option => option.name === "include-minigame") ?? { name: "include-minigame", type: ApplicationCommandOptionType.Boolean, value: true };
 
         // Prevent usage on self
         if ( InputTarget.value === interactionUser.id ) {

--- a/Commands/SlashCommands/Actions/kiss.js
+++ b/Commands/SlashCommands/Actions/kiss.js
@@ -78,7 +78,7 @@ export const SlashCommand = {
                 },
                 required: false
             },
-            {
+            /* {
                 type: ApplicationCommandOptionType.Boolean,
                 name: "block-return",
                 description: "Set to TRUE to prevent the \"Return Kiss\" Button from being included in the response",
@@ -87,7 +87,7 @@ export const SlashCommand = {
                     'en-US': "Set to TRUE to prevent the \"Return Kiss\" Button from being included in the response"
                 },
                 required: false
-            },
+            }, */
             {
                 type: ApplicationCommandOptionType.String,
                 name: "reason",

--- a/Commands/SlashCommands/Actions/lick.js
+++ b/Commands/SlashCommands/Actions/lick.js
@@ -1,0 +1,132 @@
+import { ApplicationCommandType, InteractionContextType, ApplicationIntegrationType, MessageFlags, InteractionResponseType, ApplicationCommandOptionType } from 'discord-api-types/v10';
+import { JsonResponse } from '../../../Utility/utilityMethods.js';
+import { handleActionSlashCommand } from '../../../Modules/ActionModule.js';
+import { localize } from '../../../Utility/localizeResponses.js';
+
+
+export const SlashCommand = {
+    /** Command's Name, in fulllowercase (can include hyphens)
+     * @type {String}
+     */
+    name: "lick",
+
+    /** Command's Description
+     * @type {String}
+     */
+    description: "Affectionately licks the selected target",
+
+    /** Command's Localised Descriptions
+     * @type {import('discord-api-types/v10').LocalizationMap}
+     */
+    localizedDescriptions: {
+        'en-GB': 'Affectionately licks the selected target',
+        'en-US': 'Affectionately licks the selected target'
+    },
+
+    /** Command's cooldown, in seconds (whole number integers!)
+     * @type {Number}
+     */
+    cooldown: 3,
+
+    /**
+     * Cooldowns for specific Subcommands
+     */
+    // Where "exampleName" is either the Subcommand's Name, or a combo of both Subcommand Group Name and Subcommand Name
+    //  For ease in handling cooldowns, this should also include the root Command name as a prefix
+    // In either "rootCommandName_subcommandName" or "rootCommandName_groupName_subcommandName" formats
+    subcommandCooldown: {
+        "exampleName": 3
+    },
+    
+
+    /** Get the Command's data in a format able to be registered with via Discord's API
+     * @returns {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody}
+     */
+    getRegisterData() {
+        /** @type {import('discord-api-types/v10').RESTPostAPIApplicationCommandsJSONBody} */
+        const CommandData = {};
+
+        CommandData.name = this.name;
+        CommandData.description = this.description;
+        CommandData.description_localizations = this.localizedDescriptions;
+        CommandData.type = ApplicationCommandType.ChatInput;
+        // Integration Types - 0 for GUILD_INSTALL, 1 for USER_INSTALL.
+        //  MUST include at least one. 
+        CommandData.integration_types = [ ApplicationIntegrationType.GuildInstall, ApplicationIntegrationType.UserInstall ];
+        // Contexts - 0 for GUILD, 1 for BOT_DM (DMs with the App), 2 for PRIVATE_CHANNEL (DMs/GDMs that don't include the App).
+        //  MUST include at least one. PRIVATE_CHANNEL can only be used if integration_types includes USER_INSTALL
+        CommandData.contexts = [ InteractionContextType.Guild, InteractionContextType.PrivateChannel ];
+        // Options
+        CommandData.options = [
+            {
+                type: ApplicationCommandOptionType.Mentionable,
+                name: "target",
+                description: "The target you want to lick",
+                description_localizations: {
+                    'en-GB': "The target you want to lick",
+                    'en-US': "The target you want to lick"
+                },
+                required: true
+            },
+            {
+                type: ApplicationCommandOptionType.Boolean,
+                name: "include-gif",
+                description: "Should a random GIF be displayed? (default: false)",
+                description_localizations: {
+                    'en-GB': "Should a random GIF be displayed? (default: false)",
+                    'en-US': "Should a random GIF be displayed? (default: false)"
+                },
+                required: false
+            },
+            {
+                type: ApplicationCommandOptionType.String,
+                name: "reason",
+                description: "An optional custom reason to be added onto the end of the displayed message",
+                description_localizations: {
+                    'en-GB': "An optional custom reason to be added onto the end of the displayed message",
+                    'en-US': "An optional custom reason to be added onto the end of the displayed message"
+                },
+                required: false,
+                max_length: 500
+            }
+        ];
+
+        return CommandData;
+    },
+
+    /** Handles given Autocomplete Interactions, should this Command use Autocomplete Options
+     * @param {import('discord-api-types/v10').APIApplicationCommandAutocompleteInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     */
+    async handleAutoComplete(interaction, interactionUser) {
+        return new JsonResponse({
+            type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+            data: {
+                choices: [ {name: "Not implemented yet!", value: "NOT_IMPLEMENTED"} ]
+            }
+        });
+    },
+
+    /** Runs the Command
+     * @param {import('discord-api-types/v10').APIChatInputApplicationCommandInteraction} interaction 
+     * @param {import('discord-api-types/v10').APIUser} interactionUser 
+     * @param {String} usedCommandName 
+     */
+    async executeCommand(interaction, interactionUser, usedCommandName) {
+        try {
+            return await handleActionSlashCommand(interaction, interactionUser, usedCommandName);
+        }
+        catch (err) {
+            console.error(err);
+            return new JsonResponse({
+                type: InteractionResponseType.ChannelMessageWithSource,
+                data: {
+                    flags: MessageFlags.Ephemeral,
+                    content: localize(interaction.locale, 'SLASH_COMMAND_ERROR_GENERIC')
+                }
+            });
+        }
+
+        return;
+    }
+}

--- a/Commands/SlashCommands/Actions/slap.js
+++ b/Commands/SlashCommands/Actions/slap.js
@@ -78,7 +78,7 @@ export const SlashCommand = {
                 },
                 required: false
             },
-            {
+            /* {
                 type: ApplicationCommandOptionType.Boolean,
                 name: "block-return",
                 description: "Set to TRUE to prevent the \"Return Slap\" Button from being included in the response",
@@ -87,7 +87,7 @@ export const SlashCommand = {
                     'en-US': "Set to TRUE to prevent the \"Return Slap\" Button from being included in the response"
                 },
                 required: false
-            },
+            }, */
             {
                 type: ApplicationCommandOptionType.String,
                 name: "reason",

--- a/Locales/en-GB.cjs
+++ b/Locales/en-GB.cjs
@@ -78,6 +78,9 @@ module.exports = {
     ACTION_COMMAND_OTHER_USER_SLAP: `**{{0}}** slapped **{{1}}**`,
     ACTION_COMMAND_OTHER_USER_JAIL: `**{{0}}** was sent to jail by **{{1}}**`,
     ACTION_COMMAND_OTHER_USER_BITE: `**{{0}}** gave **{{1}}** an affectionate bite`,
+    ACTION_COMMAND_OTHER_USER_LICK: `**{{0}}** gave **{{1}}** an affectionate lick`,
+    ACTION_COMMAND_OTHER_USER_GLARE: `**{{0}}** glares at **{{1}}**...`,
+    ACTION_COMMAND_OTHER_USER_EXPLODE: `**{{0}}** wants to explode **{{1}}** with their mind!`,
 
     ACTION_COMMAND_SELF_USER_HEADPAT: `**{{0}}** gave themself a headpat`,
     ACTION_COMMAND_SELF_USER_HUG: `**{{0}}** gave themself a cuddle`,
@@ -88,6 +91,9 @@ module.exports = {
     ACTION_COMMAND_SELF_USER_COOKIE: `**{{0}}** snuck a cookie out of the cookie jar for themselves`,
     ACTION_COMMAND_SELF_USER_SLAP: `**{{0}}** slapped themselves`,
     ACTION_COMMAND_SELF_USER_BITE: `**{{0}}** took a bite out of themselves`,
+    ACTION_COMMAND_SELF_USER_LICK: `**{{0}}** licked themselves`,
+    ACTION_COMMAND_SELF_USER_GLARE: `**{{0}}** glares at themself in the mirror`,
+    ACTION_COMMAND_SELF_USER_EXPLODE: `**{{0}}** thought they were a Minecraft Creeper and self-exploded!`,
 
     ACTION_COMMAND_ROLE_HEADPAT: `**{{0}}** gave everyone with **{{1}}** headpats`,
     ACTION_COMMAND_ROLE_HUG: `**{{0}}** gave everyone with **{{1}}** a group hug`,
@@ -98,6 +104,9 @@ module.exports = {
     ACTION_COMMAND_ROLE_COOKIE: `**{{0}}** gave **{{1}}** a cookie`,
     ACTION_COMMAND_ROLE_SLAP: `**{{0}}** collectively slapped **{{1}}**`,
     ACTION_COMMAND_ROLE_BITE: `**{{0}}** took a collectively bite out of **{{1}}**`,
+    ACTION_COMMAND_ROLE_LICK: `**{{0}}** collectively licked **{{1}}**`,
+    ACTION_COMMAND_ROLE_GLARE: `**{{0}}** glares collectively at **{{1}}**`,
+    ACTION_COMMAND_ROLE_EXPLODE: `**{{0}}** caught **{{1}}** in a Minecraft TNT trap!`,
 
     ACTION_COMMAND_EVERYONE_HEADPAT: `**{{0}}** gave \`@everyone\` a headpat`,
     ACTION_COMMAND_EVERYONE_HUG: `**{{0}}** gave \`@everyone\` a group hug`,
@@ -108,6 +117,9 @@ module.exports = {
     ACTION_COMMAND_EVERYONE_COOKIE: `**{{0}}** gave \`@everyone\` a cookie`,
     ACTION_COMMAND_EVERYONE_SLAP: `**{{0}}** slapped \`@everyone\``,
     ACTION_COMMAND_EVERYONE_BITE: `**{{0}}** collectively bites \`@everyone\``,
+    ACTION_COMMAND_EVERYONE_LICK: `**{{0}}** collectively licks \`@everyone\``,
+    ACTION_COMMAND_EVERYONE_GLARE: `**{{0}}** glares \`@everyone\``,
+    ACTION_COMMAND_EVERYONE_EXPLODE: `**{{0}}** used \`/tnt\` on \`@everyone\`?!`,
 
     ACTION_COMMAND_OTHER_APPS_HEADPAT: `**{{0}}** gave **{{1}}** a virtual headpat`,
     ACTION_COMMAND_OTHER_APPS_HUG: `**{{0}}** virtually cuddled **{{1}}**`,
@@ -118,6 +130,9 @@ module.exports = {
     ACTION_COMMAND_OTHER_APPS_COOKIE: `**{{0}}** gave **{{1}}** a virtual cookie`,
     ACTION_COMMAND_OTHER_APPS_SLAP: `**{{0}}** slapped **{{1}}**'s physical servers`,
     ACTION_COMMAND_OTHER_APPS_BITE: `**{{0}}** took a bite out of **{{1}}**'s internal wires`,
+    ACTION_COMMAND_OTHER_APPS_LICK: `**{{0}}** discovered electricity by licking **{{1}}**'s internal circuits`,
+    ACTION_COMMAND_OTHER_APPS_GLARE: `**{{0}}** glared at **{{1}}**'s code`,
+    ACTION_COMMAND_OTHER_APPS_EXPLODE: `**{{0}}** wants to explode **{{1}}**'s internal servers`,
 
     ACTION_COMMAND_TWILITE_HEADPAT: `**{{0}}** gave me a headpat <3`,
     ACTION_COMMAND_TWILITE_HUG: `**{{0}}** cuddled me <3`,
@@ -128,6 +143,9 @@ module.exports = {
     ACTION_COMMAND_TWILITE_COOKIE: `**{{0}}** gave me a virtual cookie!`,
     ACTION_COMMAND_TWILITE_SLAP: `**{{0}}** slapped me?! How dare you!`,
     ACTION_COMMAND_TWILITE_BITE: `**{{0}}** took a bite out of my code?!`,
+    ACTION_COMMAND_TWILITE_LICK: `**{{0}}** licked me?! Well now you know what electricity tastes like...`,
+    ACTION_COMMAND_TWILITE_GLARE: `**{{0}}** glared at me, and I glare back <:squint:1418164398404669500>`,
+    ACTION_COMMAND_TWILITE_EXPLODE: `**{{0}}** exploded...ME?!`,
 
     ACTION_COMMAND_MEE6_HEADPAT: `***{{0}}** gave **{{1}}** a headpat...*`,
     ACTION_COMMAND_MEE6_HUG: `***{{0}}** hugged **{{1}}**...*`,
@@ -138,6 +156,9 @@ module.exports = {
     ACTION_COMMAND_MEE6_COOKIE: `**{{0}}** gave **{{1}}** a cookie from the Dark Side`,
     ACTION_COMMAND_MEE6_SLAP: `**{{0}}** gave **{{1}}** a royal slapping`,
     ACTION_COMMAND_MEE6_BITE: `**{{0}}** tried to bite **{{1}}**'s rotten code, but spat it back out again!`,
+    ACTION_COMMAND_MEE6_LICK: `**{{0}}** licked **{{1}}**'s rotten code, and became ill from doing so`,
+    ACTION_COMMAND_MEE6_GLARE: `**{{0}}** glares menancingly at **{{1}}**`,
+    ACTION_COMMAND_MEE6_EXPLODE: `**{{0}}** explodes **{{1}}** over and over again!`,
 
     ACTION_RETURN_BUTTON_LABEL_HEADPAT: `Return Headpat`,
     ACTION_RETURN_BUTTON_LABEL_HUG: `Return Hug`,

--- a/Modules/ActionModule.js
+++ b/Modules/ActionModule.js
@@ -108,27 +108,33 @@ export async function handleActionSlashCommand(interaction, interactionUser, use
 
     // atEveryone
     if ( InputTarget.value === interaction.guild_id ) {
+        InputBlockReturn.value = true;
         displayMessage = localize(CurrentLocale, `ACTION_COMMAND_EVERYONE_${interaction.data.name.toUpperCase()}`, InteractionTriggeringUserDisplayName);
     }
     // atRole
     else if ( interaction.data.resolved.roles?.[InputTarget.value] != undefined ) {
         forceDisplayEmbed = true;
+        InputBlockReturn.value = true;
         displayMessage = localize(CurrentLocale, `ACTION_COMMAND_ROLE_${interaction.data.name.toUpperCase()}`, InteractionTriggeringUserDisplayName, `<@&${InputTarget.value}>`);
     }
     // atUser (used on self)
     else if ( InputTarget.value === InteractionTriggeringUserId ) {
+        InputBlockReturn.value = true;
         displayMessage = localize(CurrentLocale, `ACTION_COMMAND_SELF_USER_${interaction.data.name.toUpperCase()}`, InteractionTriggeringUserDisplayName);
     }
     // atUser (used on this app)
     else if ( InputTarget.value === DISCORD_APP_USER_ID ) {
+        InputBlockReturn.value = true;
         displayMessage = localize(CurrentLocale, `ACTION_COMMAND_TWILITE_${interaction.data.name.toUpperCase()}`, InteractionTriggeringUserDisplayName);
     }
     // atUser (used on the yucky Mee6 app)
     else if ( InputTarget.value === '159985870458322944' ) {
+        InputBlockReturn.value = true;
         displayMessage = localize(CurrentLocale, `ACTION_COMMAND_MEE6_${interaction.data.name.toUpperCase()}`, InteractionTriggeringUserDisplayName, `<@159985870458322944>`);
     }
     // atUser (used on any app that isn't TwiLite or Mee6)
     else if ( interaction.data.resolved.users?.[InputTarget.value]?.bot === true ) {
+        InputBlockReturn.value = true;
         displayMessage = localize(CurrentLocale, `ACTION_COMMAND_OTHER_APPS_${interaction.data.name.toUpperCase()}`, InteractionTriggeringUserDisplayName, `<@${InputTarget.value}>`);
     }
     // atUser (used on any human User)

--- a/Utility/interactions.js
+++ b/Utility/interactions.js
@@ -10,6 +10,9 @@ export const SlashCommands = {
     'slap': () => import('../Commands/SlashCommands/Actions/slap.js'),
     'yeet': () => import('../Commands/SlashCommands/Actions/yeet.js'),
     'bite': () => import('../Commands/SlashCommands/Actions/bite.js'),
+    'lick': () => import('../Commands/SlashCommands/Actions/lick.js'),
+    'glare': () => import('../Commands/SlashCommands/Actions/glare.js'),
+    'explode': () => import('../Commands/SlashCommands/Actions/explode.js'),
     'fish': () => import('../Commands/SlashCommands/Actions/fish.js'),
 
     // ***** FOR ROLE MENUS

--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ router.post('/twitch-webhooks', async (request, env) => {
         if ( fetchedStreamData == null ) {
             // Since this is being run on a CF Worker, we don't get a lot of time in order to do stuff.
             //   As such, I cannot do a "loop with few minutes pause between each cycle in order to wait for Twitch's API to cache it" thing here
+            console.log(`No Twitch Stream Data found for ${streamUpData.broadcaster_user_name}`);
             return new Response(null, { status: 204 });
         }
 


### PR DESCRIPTION
- [x] Hide "Return Action" Button when the target is not a single human user
- [x] Experiment with removing the "Hide Return Action Button" option for Action Slash Commands
- [x] Add `/lick`
- [x] Add `/glare`
- [x] Add `/explode`